### PR TITLE
Align the background with the page content

### DIFF
--- a/themes/gfsc/assets/sass/base/_page.sass
+++ b/themes/gfsc/assets/sass/base/_page.sass
@@ -2,6 +2,7 @@ body
   margin: 0 1rem
   background-image: url('/assets/images/background.png')
   background-size: 35px 35px
+  background-position: 28px 28px
   -moz-osx-font-smoothing: grayscale
   -webkit-font-smoothing: antialiased
   +for-tablet-portrait-up


### PR DESCRIPTION
## Description

This change sets the top left corner of the main page to sit on an intersection of the background grid instead of floating arbitrarily.

I'm not wedded to doing this, but I was finding it a bit jarring having a grid as the background without any relationship with the content.

Feel free to reject this change if the floating was intentional.