### PR TITLE
show active state in menu for current page

### DIFF
--- a/themes/gfsc/layouts/partials/header.html
+++ b/themes/gfsc/layouts/partials/header.html
@@ -8,8 +8,9 @@
       </h2>
       <nav class="header__nav nav" id="js-nav">
          <ul>
+            {{ $currentPage := . }}
             {{ range .Site.Menus.main }}
-               <li class="header__nav__item">
+               <li {{ if eq .URL $currentPage.RelPermalink }}class="active"{{ end }}>
                   <a href="{{ .URL }}">{{ .Name }}</a>
                </li>
             {{ end }}


### PR DESCRIPTION
Fixes #73

## Description

Link in main navigation needs to show 'current page' state (orange background) when on the appropriate page.