### PR TITLE
change jazz's jobtype (98)

### DIFF
--- a/content/team/staff/alexandria/index.md
+++ b/content/team/staff/alexandria/index.md
@@ -3,7 +3,7 @@ title: "Alexandria O'Leary (Aster)"
 firstname: "Alexandria"
 pronouns: "She/her"
 job: "Developer"
-jobtype: ex-staff
+jobtype: alum
 dataname: alexandria
 avatar: alexandria@400.jpg
 ---

--- a/content/team/staff/jazz/index.md
+++ b/content/team/staff/jazz/index.md
@@ -3,7 +3,7 @@ title: "Jazz Chatfield"
 firstname: "Jazz"
 pronouns: "He/him"
 job: "Web Developer"
-jobtype: ex-staff
+jobtype: alum
 dataname: jazz
 avatar: "jazz-chatfield@400.jpg"
 ---


### PR DESCRIPTION
Fixes #98

## Description

- switch Jazz to ex-staff so they don't apear in the team list but they are still credited for projects they have worked on.