### PR TITLE
fix partial border in mobile footer

### DIFF
--- a/themes/gfsc/assets/sass/base/_footer.sass
+++ b/themes/gfsc/assets/sass/base/_footer.sass
@@ -20,7 +20,7 @@
     +border(bottom)
   &__title
     grid-row: 2
-    grid-column: 1 / 2
+    grid-column: 1 / 6
     +border(bottom)
     display: grid
     align-items: center


### PR DESCRIPTION
Fixes #110

## Description

- element uses entire grid width