### PR TITLE
migrate to hugo version 0.111.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The new site will use Hugo, and feature a redesign as well as new and updated co
 
 - **Git**
 - **Github** account if you would like to make pull requests
-- **Hugo** we are using `hugo_extended_0.88.1` available for download [here](https://github.com/gohugoio/hugo/releases/tag/v0.88.1) or consult the official [documentation](https://gohugo.io/getting-started/installing/)
+- **Hugo** we are using `hugo_extended_0.111.3` available for download [here](https://github.com/gohugoio/hugo/releases/tag/v0.111.3) or consult the official [documentation](https://gohugo.io/getting-started/installing/)
 
 ## Setup & install instructions
 

--- a/netlify.toml
+++ b/netlify.toml
@@ -3,7 +3,7 @@
   publish = "public"
 
 [build.environment]
-  HUGO_VERSION = "0.88.1"
+  HUGO_VERSION = "0.111.3"
 
 [context.deploy-preview]
 command = "hugo -b $DEPLOY_PRIME_URL"

--- a/themes/gfsc/layouts/our-work/list.html
+++ b/themes/gfsc/layouts/our-work/list.html
@@ -6,7 +6,7 @@
         <li class="work__category">
             <h3 class="work__category__name">{{.Title}}</h3>
             <div class="work__category__stripes">
-              <a href="{{ .URL }}" class="work__category__link">Browse</a>
+              <a href="{{ .Permalink }}" class="work__category__link">Browse</a>
             </div>
         </li>
       {{ end }}

--- a/themes/gfsc/layouts/partials/projectindex.html
+++ b/themes/gfsc/layouts/partials/projectindex.html
@@ -1,10 +1,10 @@
 <li class="work__project">
    <div class="work__project__info">
-      <a href="{{ .URL }}" class="work__project__title">
+      <a href="{{ .Permalink }}" class="work__project__title">
          <h2 class="work__project__title">{{ .Title }}</h2>
       </a>
       <p class="work__project__summary">{{ .Description }}</p>
-      <a class="btn btn--up" href="{{ .URL }}" class="work__project__readmore">Read more</a>
+      <a class="btn btn--up" href="{{ .Permalink }}" class="work__project__readmore">Read more</a>
    </div>
 	 {{ if .Params.image }}
    <div class="work__project__image">

--- a/themes/gfsc/layouts/partials/title.html
+++ b/themes/gfsc/layouts/partials/title.html
@@ -1,11 +1,11 @@
-{{ if and (or (in .URL "our-work") (in .URL "project")) (not (eq .URL "/our-work/")) }}
+{{ if and (or (in .Permalink "our-work") (in .Permalink "project")) (not (eq .Permalink "/our-work/")) }}
   <div class="title title--borderless">
     {{ $ourwork := $.Site.GetPage "/our-work/" }}
     {{ with $ourwork }}
       <h2 class="title__main">{{ .Title }}</h2>
     {{ end }}
   </div>
-{{ else if and (or (in .URL "blog") (in .URL "project")) (not (eq .URL "/blog/")) }}
+{{ else if and (or (in .Permalink "blog") (in .Permalink "project")) (not (eq .Permalink "/blog/")) }}
   <div class="title title--blog">
     {{ $blog := $.Site.GetPage "/blog/" }}
     {{ with $blog }}
@@ -20,7 +20,7 @@
       <h2 class="title__main">{{ .Title }}</h2>
     {{ end }}
     {{ with .Params.Bigtext }}
-      <div class="title__subtitle{{ if (eq $.URL "/")}} title__subtitle--bigger{{ end }}">
+      <div class="title__subtitle{{ if (eq $.Permalink "/")}} title__subtitle--bigger{{ end }}">
         {{ if eq $.Params.Notitle true }}
           <h2 class="title__subtitle__bigtext">{{ . }}</h2>
         {{ else }}

--- a/themes/gfsc/layouts/project/single.html
+++ b/themes/gfsc/layouts/project/single.html
@@ -49,7 +49,7 @@
                {{ $themeslist := split .Params.themes " " }} {{ $themepages :=
                (.GetPage "/our-work/theme").Pages }} {{ range $themeslist }} {{
                range (where $themepages ".Params.key" .) }}
-               <a href="{{ .URL }}"> {{ .Title }} </a>
+               <a href="{{ .Permalink }}"> {{ .Title }} </a>
                {{ end }} {{ end }}
             </span>
          </p>


### PR DESCRIPTION
Fixes #156

## Description

- I choose version `0.111.3`  because we already got people set up with that when we did the towers
- mostly big find and replace job
- I've updated cloudflare environment variable and the readme

https://dash.cloudflare.com/a51f3d420a4df91985d494964c2b573d/pages/view/gfsc/ef8c40b9-ee7b-447a-8280-d41f9470b926



@geeksforsocialchange/developers
