### PR TITLE
Fix styling of blockquote on blog and projects

### DIFF
--- a/themes/gfsc/assets/sass/pages/_blog.sass
+++ b/themes/gfsc/assets/sass/pages/_blog.sass
@@ -8,8 +8,8 @@
   header + p
     font-size: 1.25rem
   blockquote, blockquote p
-    color: $primary
-    font-size: 1rem
+    // color: $primary
+    // font-size: 1rem
     font-weight: 500
     line-height: 1.666667
     a

--- a/themes/gfsc/assets/sass/pages/_project.sass
+++ b/themes/gfsc/assets/sass/pages/_project.sass
@@ -10,6 +10,16 @@
     // padding-bottom: 0
   .fancy
     margin: 0 -5rem
+  blockquote
+    margin: 0
+    border-left: 2px solid $primary
+    padding-left: 1.5em;
+    line-height: 1.666667
+    p
+      font-style: italic
+      // color: $primary
+      a
+        color: $primary
   &__title
     margin-block-start: 0
     margin-block-end: 0


### PR DESCRIPTION
Fixes #194

`<blockquote>`s on Projects and Blog:
- have left orange line
- fill width of page
- have left padding between line and text
- italic font
- larger font
- font color is now grey

## Project

![Screenshot_2023-06-26_15-27-03](https://github.com/geeksforsocialchange/gfsc-v3/assets/109223824/11027ee7-8b0f-4962-a189-c81ae351ddd4)


## Blog

![Screenshot_2023-06-26_15-27-23](https://github.com/geeksforsocialchange/gfsc-v3/assets/109223824/b34e51a6-689b-478d-9040-5d8c6013d44f)

@geeksforsocialchange/developers
