### PR TITLE
fix accessibility issues on blockquotes with tiny text

### DIFF
--- a/themes/gfsc/assets/sass/base/_typography.sass
+++ b/themes/gfsc/assets/sass/base/_typography.sass
@@ -62,13 +62,16 @@ p
   color: $copy
   margin: 1.4444rem 0
 
-.blog, .page--default .page__content
-  blockquote
-    +border(left)
-    padding-left: 1.5em
-    margin-left: 0
-    font-style: normal
+blockquote  
+  +border(left)
+  padding-left: 1.5em
+  margin-left: 0
+  font-style: normal
+  p, a
+    color: $primary
+    font-size: 1.44rem
 
+.blog, .page--default .page__content
   ol
     margin: 2rem 0
     margin-left: 1em

--- a/themes/gfsc/assets/sass/pages/_blog.sass
+++ b/themes/gfsc/assets/sass/pages/_blog.sass
@@ -7,13 +7,6 @@
     grid-template-columns: $margin-desktop 1fr
   header + p
     font-size: 1.25rem
-  blockquote, blockquote p
-    color: $primary
-    font-size: 1rem
-    font-weight: 500
-    line-height: 1.666667
-    a
-      color: $primary
   .video
     display: block
     position: relative


### PR DESCRIPTION
Fixes #230 

## Description

- increase fontsize to 1.2 of body text so we meet WCAG AA
- fixed in the typography file and removed the conflicting styles in the blog file, this accidentally fixes  #194 

Now quotes are larger some judgement will be needed by people adding content to not included really long quotes like on TSN 

https://0b10bb4d.gfsc.pages.dev/blog/2023/raftt-design-blog-2/


@geeksforsocialchange/developers
