### PR TITLE
improvements to usability of youtube shortcode

### DIFF
--- a/content/blog/2016/no-false-users/index.md
+++ b/content/blog/2016/no-false-users/index.md
@@ -13,7 +13,7 @@ I'm always struck in technical meetings how quickly people dream up imaginary pe
 
 And sure. All those things are possible. But they're fantasies. And it's OK to start with a fantasy -- decades of science fiction have guided science and engineering. Everything starts with an idea, at some level of application. But those ideas rapidly get blown wildly out of proportion. The problem is that by creating these stories and allowing them to persist, they get repeated ad nauseum as _post hoc, ego propter hoc_ justifications.
 
-{{<youtube "HL_vHDjG5Wk">}}
+{{<youtube id="HL_vHDjG5Wk" title="A scene from the West Wing where Jed Bartlett questions the relationship between correlation and causation">}}
 
 User stories[^1] are meant to be _non-fiction_. We should not be in the business of giving any more airtime to _fictional_ user stories than we need to, given how easy it is to gather them. The cart should not lead the horse. I'm sure that if you asked medical staff their top 20 desires, the lighting on the way home wouldn't even factor, and that streetlights are part of a carefully orchestrated city engineering process. And I'm sure that if one really wanted to reduce air pollution, having a networked grid of air quality sensors would give useful information, but do absolutely nothing to tackle the problem of air pollution in cities. And in the vacuum of applications for these ideas, I suspect these "straw users" will have already been referred to half a dozen times as hypothetical benefits[^2].
 

--- a/content/blog/2018/placecal-story-so-far/index.md
+++ b/content/blog/2018/placecal-story-so-far/index.md
@@ -15,7 +15,7 @@ I’ve spent the last 9 months working with [PHASE@MMU](http://msaphase.org/), S
 
 To start at the end: here’s a little clip from our launch party on 1st Dec 2017, where we organised the Winter Lights Switch-on in Hulme Park. Confused what Christmas lights and children’s choirs could possibly have to do with a smart city project? Find out more in the video…
 
-{{<youtube "sTYs_mc0Qgc">}}
+{{<youtube id="sTYs_mc0Qgc" title="a 3 minute video introducing placecal">}}
 
 ---
 

--- a/documentation/shortcodes.md
+++ b/documentation/shortcodes.md
@@ -76,3 +76,17 @@ Fig 4. Various ‘nudge’ messages that don't allow you to say no: Amtrak askin
 - `txt`: The call to action text, defaults to "Make a donation on Ko-fi to help support our work."
 - `href`: the link the button will point to, defaults to `https://ko-fi.com/gfscstudio`
 - `btn`: The text on the button, defaults to "Donate now"
+
+
+## `youtube`
+
+### Example
+
+```
+{{< youtube id="YDb8TazseN4" title="A 90 second introduction to PlaceCal" >}}
+```
+
+### Arguments
+
+- `id`: the id from the end of the youtube URL
+- `title`: a short description for accessibility that gets added to the iframe

--- a/themes/gfsc/assets/sass/base/_utility.sass
+++ b/themes/gfsc/assets/sass/base/_utility.sass
@@ -15,3 +15,17 @@
   width: 1px
   height: 1px
   overflow: hidden
+
+.video
+  display: block
+  position: relative
+  padding-bottom: 56.25%
+  height: 0
+  overflow: hidden
+  max-width: 100%
+  iframe, object, embed
+    position: absolute
+    top: 0
+    left: 0
+    width: 100%
+    height: 100%

--- a/themes/gfsc/assets/sass/pages/_blog.sass
+++ b/themes/gfsc/assets/sass/pages/_blog.sass
@@ -14,19 +14,6 @@
     line-height: 1.666667
     a
       color: $primary
-  .video
-    display: block
-    position: relative
-    padding-bottom: 56.25%
-    height: 0
-    overflow: hidden
-    max-width: 100%
-    iframe, object, embed
-      position: absolute
-      top: 0
-      left: 0
-      width: 100%
-      height: 100%
     //   z-index: 10
     //   opacity: 0.2
     // &__overlay

--- a/themes/gfsc/layouts/shortcodes/youtube.html
+++ b/themes/gfsc/layouts/shortcodes/youtube.html
@@ -1,8 +1,13 @@
+{{- $id := .Get "id" }}
+{{- $title := .Get "title" }}
 <div class="video">
-   <iframe
-      src="https://www.youtube.com/embed/{{ .Get 0 }}?wmode=opaque&modestbranding=1&rel=0&hl=ru&showinfo=0&color=white"
+  <iframe
+      src="https://www.youtube.com/embed/{{$id}}?wmode=opaque&modestbranding=1&rel=0&hl=ru&showinfo=0&color=white"
       frameborder="0"
       allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture"
       allowfullscreen
+			{{with $title}}
+			  title={{$title}}
+			{{end}}
    ></iframe>
 </div>


### PR DESCRIPTION
Fixes #176 

## Description

- youtube embed didn't work because it was being passed 2 named args but it took a single non-named arg
- converted to named params to avoid ordering bugs
- updated docs
- moved video specific css out of the blog file

@geeksforsocialchange/developers
