### PR TITLE
footnotes have style

### DIFF
--- a/themes/gfsc/assets/sass/components/_footnotes.sass
+++ b/themes/gfsc/assets/sass/components/_footnotes.sass
@@ -1,15 +1,26 @@
 .footnotes
-  font-size: 0.8rem
-  line-height: 1.43
+  margin: 0 -1rem
+  padding: 1rem
+  font-size: 1.2rem
+  // line-height: 1.43
   +border(top)
   background-color: #{$primary}20
+  +for-tablet-portrait-up
+    margin: 0 -5rem
+    padding: 1rem 5rem
+  +for-tablet-landscape-up
+    margin: 0 -2.5rem
+    padding: 1rem 2.5rem
+  +for-big-desktop-up
+    margin: 0 -7rem
+    padding: 1rem 7rem
+  hr
+    display: none
   ol
     margin: 0
-    p
-      +for-desktop-up
-        max-width: 70%
     li:before
       font-family: $freight
+      left: 0
 
 .footnote
   color: $primary

--- a/themes/gfsc/assets/sass/pages/_blog.sass
+++ b/themes/gfsc/assets/sass/pages/_blog.sass
@@ -108,18 +108,6 @@
       margin-right: $margin-desktop
       +border(right)
       padding: 0 7rem
-    .footnotes
-      margin: 0 -1rem
-      padding: 1rem
-      +for-tablet-portrait-up
-        margin: 0 -5rem
-        padding: 1rem 5rem
-      +for-tablet-landscape-up
-        margin: 0 -2.5rem
-        padding: 1rem 2rem
-      +for-big-desktop-up
-        margin: 0 -7rem
-        padding: 1rem 7rem
   &__aside
     display: flex
     width: 100%


### PR DESCRIPTION
Fixes #229 

## Description

- move some footnote styling out of a blog sass file
- footnotes are the same size as body text
- remove hr to reduce distance of footnotes to article body
- up to author if they want to place a donate element etc at the end of the article

in action https://db3da797.gfsc.pages.dev/blog/2022/why-is-it-so-hard-to-do-nice-things/

@geeksforsocialchange/developers
