### PR TITLE
add a privacy policy page

### DIFF
--- a/content/privacy-policy/index.md
+++ b/content/privacy-policy/index.md
@@ -1,0 +1,18 @@
+---
+title: Privacy policy
+bigtext: "He is seen, but he does not see; he is the object of information, never a subject in communication."
+bigtextcredit: Michel Foucault
+type: privacy
+---
+
+## What data do we collect?
+
+GFSC collects anonymous analytics data
+
+We sometimes use third party services for example [Plausable Analytics](https://plausible.io/privacy), to gather statistical data about the use of gfsc.studio. That data isn't linked to you in any way.
+
+- anonymous plausible web stats
+- email newsletter signup
+- no cookies
+- hmmm, anchor.fm and youtube embeds? do they count?
+

--- a/themes/gfsc/layouts/privacy/single.html
+++ b/themes/gfsc/layouts/privacy/single.html
@@ -1,0 +1,7 @@
+{{ define "main" }}
+  <div class="page page--default">
+    <div class="page__content page__content--doublemargin">
+      {{ .Content }}
+    </div>
+  </div>
+{{ end }}


### PR DESCRIPTION
Fixes #249 

## Description

- added a markdown file with dummy content
- added a layout file

https://249-privacy-page.gfsc.pages.dev/privacy-policy/

@geeksforsocialchange/developers
