### PR TITLE
include themes in our-work template

### DIFF
--- a/themes/gfsc/layouts/our-work/single.html
+++ b/themes/gfsc/layouts/our-work/single.html
@@ -1,4 +1,5 @@
 {{ define "main" }}
+{{$section := index (split .Path "/") 1}}
   <h3 class="category__title">{{ .Title }}</h3>
   <div class="category__content">
     {{ .Content }}
@@ -8,8 +9,15 @@
 		{{ $weighted := (where (where .Site.RegularPages "Section" "project") "Params.weight" "!=" 100 )}}
 		{{ $unweighted := ( shuffle (where (where .Site.RegularPages "Section" "project") "Params.weight" "==" 100 ) )}}
     {{ range ( $weighted | append  $unweighted )}}
-      {{ if (in .Params.categories $.Params.key )}}
-        {{- partial "projectindex.html" . -}}
+			{{ if ( eq $section "category") }}
+				{{ if (in .Params.categories $.Params.key )}}
+					{{- partial "projectindex.html" . -}}
+				{{ end }}
+      {{ end }}
+			{{ if ( eq $section "theme") }}
+				{{ if (in .Params.themes $.Params.key )}}
+					{{- partial "projectindex.html" . -}}
+				{{ end }}
       {{ end }}
     {{ end }}
   </ul>


### PR DESCRIPTION
Fixes #264

## Description

- pull the section into a variable via the path
- reuse the existing logic to filter for themes / category

https://264-theme-template.gfsc.pages.dev/our-work/theme/antiracism
https://264-theme-template.gfsc.pages.dev/our-work/theme/digitalautonomy
https://264-theme-template.gfsc.pages.dev/our-work/theme/disabilityactivism
https://264-theme-template.gfsc.pages.dev/our-work/theme/environment
https://264-theme-template.gfsc.pages.dev/our-work/theme/hulmeandmanchester
https://264-theme-template.gfsc.pages.dev/our-work/theme/localhistory
https://264-theme-template.gfsc.pages.dev/our-work/theme/mutualaid
https://264-theme-template.gfsc.pages.dev/our-work/theme/transliberation

@geeksforsocialchange/developers