### PR TITLE
only resize images that are larger than 900px wide in shortcodes

### DIFF
--- a/themes/gfsc/layouts/shortcodes/image-with-caption/start.html
+++ b/themes/gfsc/layouts/shortcodes/image-with-caption/start.html
@@ -10,8 +10,13 @@
          <img src="{{ $filename }}" alt="{{ if $alt }}{{ $alt }}{{ end }}" />
       {{ else }}       
          {{- $src := .Page.Resources.GetMatch $filename }}
-         {{- $image := $src.Resize "900x" }}
-         <img src="{{ $image.RelPermalink }}" alt="{{ if $alt }}{{ $alt }}{{ end }}" />
+         {{ if gt $src.Width 900 }}
+           {{- $image := $src.Resize "900x" }}
+					 <img src="{{ $image.RelPermalink }}" alt="{{ if $alt }}{{ $alt }}{{ end }}" />
+         {{ else }}
+           {{- $image := $src }}
+					 <img src="{{ $image.RelPermalink }}" alt="{{ if $alt }}{{ $alt }}{{ end }}" />
+         {{ end }}
       {{ end }}
    </div>
    <figcaption>

--- a/themes/gfsc/layouts/shortcodes/image.html
+++ b/themes/gfsc/layouts/shortcodes/image.html
@@ -10,8 +10,13 @@
          <img src="{{ $filename }}" alt="{{ if $alt }}{{ $alt }}{{ end }}" />
       {{ else }}       
          {{- $src := .Page.Resources.GetMatch $filename }}
-         {{- $image := $src.Resize "900x" }}
-         <img src="{{ $image.RelPermalink }}" alt="{{ if $alt }}{{ $alt }}{{ end }}" />
+         {{ if gt $src.Width 900 }}
+           {{- $image := $src.Resize "900x" }}
+					 <img src="{{ $image.RelPermalink }}" alt="{{ if $alt }}{{ $alt }}{{ end }}" />
+         {{ else }}
+           {{- $image := $src }}
+					 <img src="{{ $image.RelPermalink }}" alt="{{ if $alt }}{{ $alt }}{{ end }}" />
+         {{ end }}
       {{ end }}
    </div>
 </figure>


### PR DESCRIPTION
Fixes #276 

## Description

- check width of image before resizing.


@geeksforsocialchange/developers
