### PR TITLE
267 tags on project list

### DIFF
--- a/themes/gfsc/assets/sass/components/_theme-tags.sass
+++ b/themes/gfsc/assets/sass/components/_theme-tags.sass
@@ -5,3 +5,4 @@
   display: flex
   flex-wrap: wrap
   gap: 0.5rem
+  font-size: 1rem

--- a/themes/gfsc/assets/sass/components/_theme-tags.sass
+++ b/themes/gfsc/assets/sass/components/_theme-tags.sass
@@ -1,0 +1,7 @@
+.theme-tags
+  list-style: none
+  margin: 0
+  padding: 0
+  display: flex
+  flex-wrap: wrap
+  gap: 0.5rem

--- a/themes/gfsc/assets/sass/main.scss
+++ b/themes/gfsc/assets/sass/main.scss
@@ -22,6 +22,7 @@
 @import "components/_strip";
 @import "components/_tables";
 @import "components/_teaser";
+@import "components/_theme-tags";
 @import "components/_vendor";
 @import "components/_venn";
 @import "components/_windows";

--- a/themes/gfsc/assets/sass/pages/_work.sass
+++ b/themes/gfsc/assets/sass/pages/_work.sass
@@ -80,6 +80,7 @@
         +border(sides)
     &__title
       margin: 0
+      margin-bottom: 0.5rem
       text-decoration: none
     &__readmore
       +border(all)

--- a/themes/gfsc/layouts/partials/projectindex.html
+++ b/themes/gfsc/layouts/partials/projectindex.html
@@ -12,8 +12,12 @@
          <h2 class="work__project__title">{{ .Title }}</h2>
       </a>
 			<ul role="list" class="theme-tags">
-				{{ range $projectThemes}}
-				<li><a href=" {{ (index $themes .).link}} "> {{ (index $themes .).title}} </a></li>
+				{{ range $index, $val := $projectThemes}}
+			    {{if ( ge   (add $index 1 ) ( len $projectThemes ))}}
+				    <li><a href=" {{ (index $themes $val).link}} "> {{ (index $themes $val).title}} </a></li>
+				  {{else}}
+				    <li><a href=" {{ (index $themes $val).link}} "> {{ (index $themes $val).title}}, </a></li>
+				  {{end}}
 				{{end}}
 			</ul>
       <p class="work__project__summary">{{ .Description }}</p>

--- a/themes/gfsc/layouts/partials/projectindex.html
+++ b/themes/gfsc/layouts/partials/projectindex.html
@@ -1,25 +1,9 @@
-{{ $themes := dict }}
-{{ $themePages := $.Site.GetPage "/our-work/theme/" }}
-{{ range $themePages.RegularPages}}
-  {{$themes = merge $themes (dict .Params.key (dict "title" .Title  "link" .Permalink ))}}
-{{end}}
-
-{{ $projectThemes := split .Params.themes " "}}
-
 <li class="work__project">
    <div class="work__project__info">
       <a href="{{ .Permalink }}" class="work__project__title">
          <h2 class="work__project__title">{{ .Title }}</h2>
       </a>
-			<ul role="list" class="theme-tags">
-				{{ range $index, $val := $projectThemes}}
-			    {{if ( ge   (add $index 1 ) ( len $projectThemes ))}}
-				    <li><a href=" {{ (index $themes $val).link}} "> {{ (index $themes $val).title}} </a></li>
-				  {{else}}
-				    <li><a href=" {{ (index $themes $val).link}} "> {{ (index $themes $val).title}}, </a></li>
-				  {{end}}
-				{{end}}
-			</ul>
+			{{- partial "themeTags.html" . -}}
       <p class="work__project__summary">{{ .Description }}</p>
       <a class="btn btn--up" href="{{ .Permalink }}" class="work__project__readmore">Read more</a>
    </div>

--- a/themes/gfsc/layouts/partials/projectindex.html
+++ b/themes/gfsc/layouts/partials/projectindex.html
@@ -1,8 +1,21 @@
+{{ $themes := dict }}
+{{ $themePages := $.Site.GetPage "/our-work/theme/" }}
+{{ range $themePages.RegularPages}}
+  {{$themes = merge $themes (dict .Params.key (dict "title" .Title  "link" .Permalink ))}}
+{{end}}
+
+{{ $projectThemes := split .Params.themes " "}}
+
 <li class="work__project">
    <div class="work__project__info">
       <a href="{{ .Permalink }}" class="work__project__title">
          <h2 class="work__project__title">{{ .Title }}</h2>
       </a>
+			<ul>
+				{{ range $projectThemes}}
+				<li><a href=" {{ (index $themes .).link}} "> {{ (index $themes .).title}} </a></li>
+				{{end}}
+			</ul>
       <p class="work__project__summary">{{ .Description }}</p>
       <a class="btn btn--up" href="{{ .Permalink }}" class="work__project__readmore">Read more</a>
    </div>

--- a/themes/gfsc/layouts/partials/projectindex.html
+++ b/themes/gfsc/layouts/partials/projectindex.html
@@ -11,7 +11,7 @@
       <a href="{{ .Permalink }}" class="work__project__title">
          <h2 class="work__project__title">{{ .Title }}</h2>
       </a>
-			<ul>
+			<ul role="list" class="theme-tags">
 				{{ range $projectThemes}}
 				<li><a href=" {{ (index $themes .).link}} "> {{ (index $themes .).title}} </a></li>
 				{{end}}

--- a/themes/gfsc/layouts/partials/themeTags.html
+++ b/themes/gfsc/layouts/partials/themeTags.html
@@ -1,0 +1,18 @@
+{{ $themes := dict }}
+{{ $themePages := $.Site.GetPage "/our-work/theme/" }}
+{{ range $themePages.RegularPages}}
+  {{$themes = merge $themes (dict .Params.key (dict "title" .Title  "link" .Permalink ))}}
+{{end}}
+
+{{ $projectThemes := split .Params.themes " "}}
+
+
+<ul role="list" class="theme-tags">
+	{{ range $index, $val := $projectThemes}}
+		{{if ( ge   (add $index 1 ) ( len $projectThemes ))}}
+			<li><a href=" {{ (index $themes $val).link}} "> {{ (index $themes $val).title}} </a></li>
+		{{else}}
+			<li><a href=" {{ (index $themes $val).link}} "> {{ (index $themes $val).title}}, </a></li>
+		{{end}}
+	{{end}}
+</ul>


### PR DESCRIPTION
Fixes #267 

## Description

- add themes to project preview cards
- link through to filtered theme list
- create a `themesTag` partial so we can add it to the project single page when we are ready
- use link styling because they are links!

@geeksforsocialchange/developers
