### PR TITLE
Fix broken shortcode & clip the wings on overzealous prettier

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -9,8 +9,10 @@ bin/htmltest
 node_modules
 npm-debug.log
 
-# things prettier refuses to format
+# things prettier refuses to format / should not be allowed to format
+themes/gfsc/layouts/shortcodes/image-with-caption/start.html
 themes/gfsc/layouts/shortcodes/image-with-caption/end.html
+themes/gfsc/layouts/shortcodes/gallery-with-caption/start.html
 themes/gfsc/layouts/shortcodes/gallery-with-caption/end.html
 themes/gfsc/layouts/project/single.html
 themes/gfsc/layouts/partials/footer.html

--- a/themes/gfsc/layouts/shortcodes/gallery-with-caption/start.html
+++ b/themes/gfsc/layouts/shortcodes/gallery-with-caption/start.html
@@ -32,6 +32,4 @@
         <path d="M4.3,3.72H0.7V0.38h3.6V3.72z M4.3,18.62H0.7V5.88h3.6V18.62z" />
       </svg>
     </span>
-    <span class="desc" markdown="1"></span>
-  </figcaption>
-</figure>
+    <span class="desc" markdown="1">

--- a/themes/gfsc/layouts/shortcodes/image-with-caption/start.html
+++ b/themes/gfsc/layouts/shortcodes/image-with-caption/start.html
@@ -37,6 +37,4 @@
         <path d="M4.3,3.72H0.7V0.38h3.6V3.72z M4.3,18.62H0.7V5.88h3.6V18.62z" />
       </svg>
     </span>
-    <span class="desc" markdown="1"> </span>
-  </figcaption>
-</figure>
+    <span class="desc" markdown="1">


### PR DESCRIPTION
Fixes #294 

## Description

- Fixes broken shortcode - prettier had helpfully added closing tags onto the first part of the shortcode which meant the elements were closed before we could add the text
- Checks all two part shortcodes are added to `.prettierignore`

@geeksforsocialchange/developers
