### PR TITLE
improve footer contrast

### DIFF
--- a/themes/gfsc/assets/sass/base/_footer.sass
+++ b/themes/gfsc/assets/sass/base/_footer.sass
@@ -117,11 +117,11 @@
     display: grid
     align-items: center
     p
-      color: $primary
+      color: $copy
       margin: 0.75rem 0
       line-height: 1.2em
     a
-      color: $primary
+      color: $copy
     +for-tablet-portrait-up
       grid-row: 2
       grid-column: 2 / 3


### PR DESCRIPTION
Fixes #306 

## Description

- Make it the same color as other text.
- This feels like the easiest fix. Making it large and bright orange would draw to much attention too details that are not the main content.

@geeksforsocialchange/developers
