### PR TITLE
improve color contrast of unordered lists in projects

### DIFF
--- a/themes/gfsc/assets/sass/pages/_project.sass
+++ b/themes/gfsc/assets/sass/pages/_project.sass
@@ -73,7 +73,25 @@
       a
         color: $primary
         margin: 0 0.25rem
-    &__content
+  &__content
+    ul
+      list-style-type: none
+      margin: 2rem 0
+      padding: 0
+      position: relative
+      font-weight: 500
+      line-height: 1.54545
+      color: $copy
+      li
+        margin-bottom: 1rem
+        margin-left: 2rem
+        line-height: 1.54545
+      li:before
+        content: "\2022"
+        position: absolute
+        left: 0
+        color: $primary
+        margin-right: 1rem
   &__footer
     display: none
     margin: 0 -5rem


### PR DESCRIPTION
Fixes #321

## Description

- add the same list stylings from typography into the projects sass file.
- it's scoped under `.project__content` because otherwise the themes list inherits some very large margins

@geeksforsocialchange/developers
