### PR TITLE
Burger menu keyboard tab navigation

### DIFF
--- a/themes/gfsc/assets/sass/base/_header.sass
+++ b/themes/gfsc/assets/sass/base/_header.sass
@@ -92,8 +92,6 @@
     grid-row: 1
     order: 2
     align-self: center
-    &:focus
-      outline: 0
     svg
       margin-left: 1rem
     +for-tablet-portrait-up

--- a/themes/gfsc/layouts/partials/header.html
+++ b/themes/gfsc/layouts/partials/header.html
@@ -6,16 +6,6 @@
         <div class="header__logo" role="presentation"></div>
       </a>
     </h2>
-    <nav class="header__nav nav" id="js-nav">
-      <ul>
-        {{ $currentPage := . }}
-        {{ range .Site.Menus.main }}
-          <li {{ if eq .URL $currentPage.RelPermalink }}class="active"{{ end }}>
-            <a href="{{ .URL }}">{{ .Name }}</a>
-          </li>
-        {{ end }}
-      </ul>
-    </nav>
     <button class="header__toggle nav__toggle" id="js-toggle">
       Menu
       <svg
@@ -31,6 +21,16 @@
         </g>
       </svg>
     </button>
+    <nav class="header__nav nav" id="js-nav">
+      <ul>
+        {{ $currentPage := . }}
+        {{ range .Site.Menus.main }}
+          <li {{ if eq .URL $currentPage.RelPermalink }}class="active"{{ end }}>
+            <a href="{{ .URL }}">{{ .Name }}</a>
+          </li>
+        {{ end }}
+      </ul>
+    </nav>
     <div
       class="header__strip--1 strip strip--circles"
       role="presentation"


### PR DESCRIPTION
Fixes #322 

## Description

- on devices that have the burger menu present
  - allow focus to show up as an outline
  - can tab into and out of the menu (when not showing the nav links)
  - can toggle the nav links
  - when nav links visible- can tab through nav links after burger menu

@geeksforsocialchange/developers
