### PR TITLE
add skip to content link

### DIFF
--- a/themes/gfsc/assets/sass/base/_utility.sass
+++ b/themes/gfsc/assets/sass/base/_utility.sass
@@ -16,6 +16,21 @@
   height: 1px
   overflow: hidden
 
+.screen-reader-only--focus:focus 
+  background-color: $primary
+  color: $secondary
+  font-family: $balboa
+  font-weight: 600
+  height: max-content
+  left: 50%
+  transform: translate(-50%, 0)
+  padding: 1rem
+  position: absolute
+  top: auto
+  width: max-content
+  z-index: 100
+
+
 .video
   display: block
   position: relative

--- a/themes/gfsc/layouts/_default/baseof.html
+++ b/themes/gfsc/layouts/_default/baseof.html
@@ -2,9 +2,12 @@
 <html lang="en">
   {{- partial "head.html" . -}}
   <body>
+    <a href="#content" class="screen-reader-only screen-reader-only--focus"
+      >Skip to content</a
+    >
     <div class="page__wrapper">
       {{- partial "header.html" . -}}
-      <main>
+      <main id="content">
         {{- partial "title.html" . -}}
         {{- block "main" . }}{{- end }}
       </main>


### PR DESCRIPTION
Fixes #324 

## Description

- first tab item links past the header/nav and into the main element

@geeksforsocialchange/developers
