### PR TITLE
Change title tags to `<h1>` tags

### DIFF
--- a/themes/gfsc/layouts/partials/title.html
+++ b/themes/gfsc/layouts/partials/title.html
@@ -2,7 +2,7 @@
   <div class="title title--borderless">
     {{ $ourwork := $.Site.GetPage "/our-work/" }}
     {{ with $ourwork }}
-      <h2 class="title__main">{{ .Title }}</h2>
+      <h1 class="title__main">{{ .Title }}</h1>
     {{ end }}
   </div>
 {{ else if and (or (in .Permalink "blog") (in .Permalink "project")) (not (eq .Permalink "/blog/")) }}
@@ -26,7 +26,7 @@
         role="presentation"
       ></div>
     {{ else }}
-      <h2 class="title__main">{{ .Title }}</h2>
+      <h1 class="title__main">{{ .Title }}</h1>
     {{ end }}
     {{ with .Params.Bigtext }}
       <div
@@ -35,7 +35,7 @@
         {{ end }}"
       >
         {{ if eq $.Params.Notitle true }}
-          <h2 class="title__subtitle__bigtext">{{ . }}</h2>
+          <h1 class="title__subtitle__bigtext">{{ . }}</h1>
         {{ else }}
           <p class="title__subtitle__bigtext">{{ . }}</p>
         {{ end }}


### PR DESCRIPTION
Fixes #308

## Description

Use correct `<h1>` tags on pages to improve accessibility and SEO.

Pages fixed
- `/studio`
- `/collective`
- `/our-work`
- `/team`
- `/support`
- `/project/:slug`
- `/contact`

Other pages
- `/blog/:slug` (pulls the title from the blog post)
- `/blog` (title is missing from page)
- `/` (title is missing here altogether)


@geeksforsocialchange/developers
