### PR TITLE
Improve alt text on gallery images

### DIFF
--- a/content/blog/2018/placecal-story-so-far/index.md
+++ b/content/blog/2018/placecal-story-so-far/index.md
@@ -30,7 +30,7 @@ This is methodology is called _asset-based community development_ or _ABCD_: aid
 
 _Before continuing, it’s worth noting how hard it can be to write up this kind of work. What “the partnership” is or means to anyone at any given moment can be extremely hard (and often undesirable) to pin down. Decentralised resident-led groups, like most things in society, are complex structures that we believe offer the only real possibility for genuine change: however in doing so they make it extremely hard to write about exactly who did what when without making it sound like credit is being taken for the actions of a wider group. Therefore: when the rest of this article refers to “the partnership” or “we” it is referring specifically to me (Kim Foale), the Hulme Age Friendly Board, and PHASE@MMU working together to create PlaceCal and its requisite theoretical background. If anyone has any ideas how to resolve this issue with language, we are all ears!_
 
-{{<gallery-with-caption/start srcs="1.png 2.png" alts="1. A photo of a neighbourhood partnership in action. 2. A snapshot of a board meeting in Hulme" classList="image--frame">}}
+{{<gallery-with-caption/start srcs="1.png 2.png" alts="1. A photo of a neighbourhood partnership in action | 2. A snapshot of a board meeting in Hulme" classList="image--frame">}}
 {{<rawhtml>}}1. A photo of a neighbourhood partnership in action. 2. A snapshot of a board meeting in Hulme{{</rawhtml>}}
 {{<gallery-with-caption/end>}}
 
@@ -46,7 +46,7 @@ This story is a great example of how the things that prevent community wellness 
 
 This brings us back to the role of the architect in partnership work. Architects are commonly seen as people who simply design buildings. In this case, building a disabled toilet is something a second year undergraduate student or a decent plumber could do: and of course, someone does have to design the thing. The much harder work lies in identifying the problem using the available data: starting from analysing maps of bus routes and public health data, through talking to residents to find the reason for the problems, to creating the conditions to make the change itself.
 
-{{<gallery-with-caption/start srcs="3.png 4.jpeg" alts="The final result: not too complex!" classList="image--toilet">}}
+{{<gallery-with-caption/start srcs="3.png 4.jpeg" alts="An architectural layout drawing for a disabled toilet | A photograph of a disabled toilet" classList="image--toilet">}}
 The final result: not too complex!
 {{<gallery-with-caption/end>}}
 
@@ -172,13 +172,13 @@ The lovely neighbourhood team sorting amends. L-R Lesley (One Manchester), Debbi
 
 Between us we distributed 10,000 leaflets and posters down the major shopping streets in Hulme and Moss Side, put them through people’s letter boxes, gave them to parents at schools, and generally plastered the area. By now you’re probably getting the point that by making one really good source of information together, we multiplied our capacity and reach. Through this process we had loads of conversations with local shops and businesses, made some more connections, and got some great feedback. We’re looking forward to being able to go back and see how people got on!
 
-{{<gallery-with-caption/start srcs="9.jpeg 10.jpeg" alts="10,000 leaflets is a lot of leaflets…" classList="image--frame">}}
+{{<gallery-with-caption/start srcs="9.jpeg 10.jpeg" alts="A box of hulme winter lights switch on leaflets | A selection of hulme winter lights switch on leaflets laid on a table" classList="image--frame">}}
 10,000 leaflets is a lot of leaflets…
 {{<gallery-with-caption/end>}}
 
 The event itself was a huge success with hundreds of people coming throughout the day. Over the course of the day we had carols from local schools in the park, live music, the One Manchester bus, a fire engine with a snow machine, loads of food from local organisations, mosques and churches, and of course the PlaceCal demonstrations which nearly got lost in the festivities! We also got to line up with Z Arts current production for people who wanted somewhere to go afterwards. The highlight for me was wondering why it had got quiet for a bit, before realising the imitable DJ [Lord Kemoy Walker](https://twitter.com/kemoywalker) had a dancefloor full of kids dancing to _Gangnam Style_ just before wrapup!
 
-{{<gallery-with-caption/start srcs="11.jpeg 12.jpeg 12.jpeg 14.jpeg 15.jpeg 16.jpeg 17.jpeg 18.jpeg" alts="Photos from our launch" classList="image--frame">}}
+{{<gallery-with-caption/start srcs="11.jpeg 12.jpeg 12.jpeg 14.jpeg 15.jpeg 16.jpeg 17.jpeg 18.jpeg" alts="Musicians playing in front of a mural | a crowd gathered outside near a fire engine with artificial snow | a crowd gathered outside | school children singing on a bus | a presentation of placecal being given | a busy canteen at christmas time | an audience listening to a presentation | a community space filled with children doing craft activities and dancing" classList="image--frame">}}
 Photos from our launch
 {{<gallery-with-caption/end>}}
 

--- a/content/blog/2021/everything-is-connected/index.md
+++ b/content/blog/2021/everything-is-connected/index.md
@@ -104,7 +104,7 @@ This is, of course, anathema to the current way apps are developed. It’s hard 
 
 ‘Sign up’ and ‘maybe later’, like two options that a pushy guy at a nightclub trying to get you to go home with him might present to you, are now the [default dark pattern](https://blog.prototypr.io/not-now-a91c75ad35b6) for many websites. Many of us will have had “you didn’t complete your order” adverts that seem to inexplicably follow us from site to site -- proof to even the casual user that the websites they visit are not self-contained units.
 
-{{<gallery-with-caption/start srcs="amtrak.png push-knowledge.png cart-waiting.png" alts="Fig 4. Various ‘nudge’ messages that don't allow you to say no: Amtrak asking 'send me offers' or 'maybe later'; SEMrush asking 'okay' or 'ask me later', and an email asking us to 'finish your purchase'." classList="image--1-2 image--frame">}}
+{{<gallery-with-caption/start srcs="amtrak.png push-knowledge.png cart-waiting.png" alts="Amtrak asking 'send me offers' or 'maybe later'| SEMrush asking 'okay' or 'ask me later' | an email asking us to 'finish your purchase'" classList="image--1-2 image--frame">}}
 Fig 4. Various ‘nudge’ messages that don't allow you to say no: Amtrak asking 'send me offers' or 'maybe later'; SEMrush asking 'okay' or 'ask me later', and an email asking us to 'finish your purchase'.
 {{<gallery-with-caption/end>}}
 
@@ -120,7 +120,7 @@ In the desire to see [data as the new oil](https://www.forbes.com/sites/forbeste
 
 Interaction designer Brett Victor (2006) defines [three kinds of software](http://worrydream.com/MagicInk/): information software, manipulation software, and communication software. Information software is where you want to find something out (Wikipedia). Manipulation software is where you want to make something (Word, Photoshop). Communications software is where you want to communicate with someone else (Email, WhatsApp).
 
-{{<gallery-with-caption/start srcs="information.png manipulation.png communication.png" alts="Fig 5. Diagrams of the three kinds of software (Victor, 2006)." classList="image--3 image--frame">}}
+{{<gallery-with-caption/start srcs="information.png manipulation.png communication.png" alts="a diagram showing information passing from a computer to a person (the model) | a diagram showing feedback passing from a computer (the model) to a person and manipulation passing from the person to the computer | a diagram showing two people communicating to each other and conceiving of the same idea (the model)" classList="image--3 image--frame">}}
 Fig 5. Diagrams of the three kinds of software (Victor, 2006).
 {{<gallery-with-caption/end>}}
 
@@ -136,7 +136,7 @@ Even software that is explicitly designed to help vulnerable people often falls 
 
 While I was writing this piece, I got an Instagram ad which perfectly captures the more orthodox position of modern startup design (see below). This app actively encourages people to go around taking photographs of homeless people and uploading them to their server, where we can see their _name and balance_. Before even getting into the root causes of homelessness and what is actually needed in the sector (hint: houses), homelessness, as I have already mentioned, is now grounds for deportation. It only takes a second to realise the harm that could be caused by this initiative. While seemingly extreme, this is not unlike dozens of other ideas I’ve heard in ‘tech for good’ circles.
 
-{{<gallery-with-caption/start srcs="facedonate-1.jpg facedonate-2.png" alts="Fig 6. Instagram advert I received for Face Donate (left) and a screenshot from their website (right)." classList="image--frame">}}
+{{<gallery-with-caption/start srcs="facedonate-1.jpg facedonate-2.png" alts="Instagram advert that says '@face_donate The social good network, gicing is no longer faceless. There is a better equation for caring, one with transparency, efficiency and trust at its core - when you know how your donation is spent and wh...' | Screenshot from face donate website explainging how to take a photograph of a donation recipient in order to be able to track the donations they have received" classList="image--frame">}}
 Fig 6. Instagram advert I received for Face Donate (left) and a screenshot from their website (right).
 {{<gallery-with-caption/end>}}
 

--- a/content/blog/2021/technology-isnt-a-magic-wand/index.md
+++ b/content/blog/2021/technology-isnt-a-magic-wand/index.md
@@ -36,7 +36,7 @@ It fitted in that gap between "I need that!" and "But do I really?", the gap tha
 
 But a lot of inventions of this era were seemingly designed to fit in this _Innovations_ sized-hole. The promise that all of society's smallest problems could be improved by upscaling your toaster was an intoxicating one.
 
-{{<gallery-with-caption/start srcs="scarecat.jpg gianthand.jpg" alts="Some items listed barely pass as innovations. Scare Cat (left) and Giant Hands (right)." classList="image--frame">}}
+{{<gallery-with-caption/start srcs="scarecat.jpg gianthand.jpg" alts="A silhouette of a cat made from wood with glass beads for eyes | a person gathering leaves using what appears to be two giant plastic combs" classList="image--frame">}}
 Some items listed barely pass as innovations. Scare Cat (left) and Giant Hands (right).[^1]
 {{<gallery-with-caption/end>}}
 

--- a/content/blog/2021/what-happened-to-nuclear-free-manchester/index.md
+++ b/content/blog/2021/what-happened-to-nuclear-free-manchester/index.md
@@ -55,7 +55,7 @@ In 2005, one of the architects of this declaration Cllr Bill Risby stated:
 
 in the 1980s-90s the slogan "Manchester: a Nuclear Free City" was widely used on signs. You can still see them around town today. This [Manchester Evening News](https://www.manchestereveningnews.co.uk/news/greater-manchester-news/truth-iconic-manchester-emblem-top-14925461) longread talks about the history of where it came from.
 
-{{<gallery-with-caption/start srcs="0_Nuclear-Free-2.jpg 0_Nuclear1.jpg" alts="Left: a poster saying 'Manchester: Working for a Nuclear Free City'. The text is gold and there is a white sillouhette of a dove on a blue background. Right: a booklet published by Manchester City Council entitled 'Emergency Planning and Nuclear War in Greater Manchester'" classList="image--frame">}}
+{{<gallery-with-caption/start srcs="0_Nuclear-Free-2.jpg 0_Nuclear1.jpg" alts="A poster saying 'Manchester: Working for a Nuclear Free City'. The text is gold and there is a white sillouhette of a dove on a blue background | A booklet published by Manchester City Council entitled 'Emergency Planning and Nuclear War in Greater Manchester'" classList="image--frame">}}
 Left: a poster saying 'Manchester: Working for a Nuclear Free City'. The text is gold and there is a white sillouhette of a dove on a blue background. Right: a booklet published by Manchester City Council entitled 'Emergency Planning and Nuclear War in Greater Manchester'
 {{<gallery-with-caption/end>}}
 


### PR DESCRIPTION
Fixes #315

## Description

- Updates some gallery alt text so that it better describes the images & is applied to images individually

## Fixes

https://3718cd02.gfsc.pages.dev/blog/2018/placecal-story-so-far/
https://3718cd02.gfsc.pages.dev/blog/2021/everything-is-connected/
https://3718cd02.gfsc.pages.dev/blog/2021/technology-isnt-a-magic-wand/
https://3718cd02.gfsc.pages.dev/blog/2021/what-happened-to-nuclear-free-manchester/

@geeksforsocialchange/developers
