### PR TITLE
Hamburger menu js-free graceful degradation

### DIFF
--- a/config/_default/menu.yml
+++ b/config/_default/menu.yml
@@ -2,21 +2,35 @@ main:
   - name: "The Studio"
     url: /studio/
     weight: 1
+    params:
+      summary: "[cCc] What we aim to do"
   - name: "The Collective"
     url: /collective/
     weight: 2
+    params:
+      summary: "[cCc] What we aim to do"
   - name: "The Team"
     url: /team/
     weight: 4
+    params:
+      summary: "[cCc] Who we are"
   - name: "Our Work"
     url: /our-work/
     weight: 3
+    params:
+      summary: "[cCc] What we have done"
   - name: "Support Us"
     url: /support/
     weight: 5
+    params:
+      summary: "[cCc]"
   - name: "Contact"
     url: /contact/
     weight: 7
+    params:
+      summary: "[cCc] Get in touch"
   - name: "Blog"
     url: /blog/
     weight: 6
+    params:
+      summary: "[cCc] Our lives, thoughts, projects, fears, etc."

--- a/content/nav/index.md
+++ b/content/nav/index.md
@@ -1,0 +1,4 @@
+---
+title: Navigation
+type: nav
+---

--- a/static/assets/js/main.js
+++ b/static/assets/js/main.js
@@ -3,8 +3,12 @@
     toggle: document.getElementById("js-toggle"),
     nav: document.getElementById("js-nav"),
     doToggle: function (e) {
+      e.preventDefault();
+
       this.toggle.classList.toggle("expanded");
       this.nav.classList.toggle("expanded");
+
+      return false;
     },
   };
 

--- a/themes/gfsc/layouts/nav/single.html
+++ b/themes/gfsc/layouts/nav/single.html
@@ -1,0 +1,7 @@
+{{ define "main" }}
+  <ul>
+    {{ range .Site.Menus.main }}
+      <li><a href="{{ .URL }}">{{ .Name }}</a> {{ .Params.summary }}</li>
+    {{ end }}
+  </ul>
+{{ end }}

--- a/themes/gfsc/layouts/partials/header.html
+++ b/themes/gfsc/layouts/partials/header.html
@@ -6,7 +6,7 @@
         <div class="header__logo" role="presentation"></div>
       </a>
     </h2>
-    <button class="header__toggle nav__toggle" id="js-toggle">
+    <a href="/nav" class="header__toggle nav__toggle" id="js-toggle">
       Menu
       <svg
         xmlns="http://www.w3.org/2000/svg"
@@ -20,7 +20,7 @@
           <line x2="30" transform="translate(308 64)" />
         </g>
       </svg>
-    </button>
+    </a>
     <nav class="header__nav nav" id="js-nav">
       <ul>
         {{ $currentPage := . }}


### PR DESCRIPTION
Fixes #325

## Description

When a user who has no js enabled, the hamburger menu becomes a link to a static navigation page.

Looks like

![Screenshot_2023-07-11_23-00-04](https://github.com/geeksforsocialchange/gfsc-v3/assets/109223824/66bfdab9-7808-488f-9ca5-064d3c4d6eee)

Tasks pending
- the hamburger menu link out-by-one pixel alignment
- some polish on the nav page
- content for the summaries

@geeksforsocialchange/developers
