### PR TITLE
add partial that shows blogs related to a project page

### DIFF
--- a/archetypes/blog/index.md
+++ b/archetypes/blog/index.md
@@ -6,4 +6,5 @@ date: {{ time.Format "2006-01-02" .Date  }}
 author: ""
 social:
 illustrator: ""
+project: ""
 ---

--- a/archetypes/blog/index.md
+++ b/archetypes/blog/index.md
@@ -6,5 +6,5 @@ date: {{ time.Format "2006-01-02" .Date  }}
 author: ""
 social:
 illustrator: ""
-project: ""
+projects: ""
 ---

--- a/content/blog/2022/rafft-design-blog/index.md
+++ b/content/blog/2022/rafft-design-blog/index.md
@@ -7,6 +7,7 @@ author: emma, kim
 illustrator: emma
 social: cover.jpg
 aliases: /raftt-design-diary
+project: the-towers
 ---
 
 {{<image src="cover.jpg" alt="An abstract image featuring a black and white shot of some mills with some white lines and coloured blobs on the top suggesting a user interface">}}

--- a/content/blog/2022/rafft-design-blog/index.md
+++ b/content/blog/2022/rafft-design-blog/index.md
@@ -7,7 +7,8 @@ author: emma, kim
 illustrator: emma
 social: cover.jpg
 aliases: /raftt-design-diary
-project: the-towers
+projects:
+  - the-towers
 ---
 
 {{<image src="cover.jpg" alt="An abstract image featuring a black and white shot of some mills with some white lines and coloured blobs on the top suggesting a user interface">}}

--- a/content/blog/2023/raftt-design-blog-2/index.md
+++ b/content/blog/2023/raftt-design-blog-2/index.md
@@ -7,6 +7,7 @@ author: emma, honor
 illustrator: emma
 social: cover.jpg
 aliases: /raftt-design-diary-2
+project: the-towers
 ---
 
 {{<image src="cover.jpg" alt="A black and white shot of a tower being demolished by a tall piece of heavy machinery with colourful birds flying from the wreckage">}}

--- a/content/blog/2023/raftt-design-blog-2/index.md
+++ b/content/blog/2023/raftt-design-blog-2/index.md
@@ -7,7 +7,8 @@ author: emma, honor
 illustrator: emma
 social: cover.jpg
 aliases: /raftt-design-diary-2
-project: the-towers
+projects:
+  - the-towers
 ---
 
 {{<image src="cover.jpg" alt="A black and white shot of a tower being demolished by a tall piece of heavy machinery with colourful birds flying from the wreckage">}}

--- a/content/blog/2023/raftt-design-diary-3/index.md
+++ b/content/blog/2023/raftt-design-diary-3/index.md
@@ -7,6 +7,7 @@ author: emma, honor, rebecca
 illustrator: emma
 social: cover.jpg
 aliases: /raftt-design-blog-3
+project: the-towers
 ---
 
 {{<image src="cover.jpg" alt="A black and white shot of two towers at a junction with colourful writing across it reading 'The Towers' and 'A history of Summervale and Crossbank'">}}
@@ -15,27 +16,27 @@ Welcome to the final instalment of this mini series of blogs about our recent lo
 
 To recap in brief, RAFTT stands for ‘Rise and Fall of Two Towers’, which was the project’s initial name. It ended up being titled “The Towers: A history of Summervale and Crossbank”. Summervale House and Crossbank House were two tower blocks of flats built in Oldham in the 1970s. Slated for demolition and replacement with low rise housing which was more needed by the community, GFSC worked with the owners of the Towers, First Choice Homes Oldham (FCHO), to put together a funded project proposal, which was ultimately supported by the Heritage Lottery Fund.
 
-The project’s aims — 
+The project’s aims —
 
-1) to collect and document the history of the area, which might otherwise be lost as the towers residents end up scattered far and wide
+1. to collect and document the history of the area, which might otherwise be lost as the towers residents end up scattered far and wide
 
-2) To involve the local community with a specific aim of increasing their digital skills. It was unclear at the start of the project how this might manifest, as it depended to a great extent on the interest and existing digital skills of the community. 
+2. To involve the local community with a specific aim of increasing their digital skills. It was unclear at the start of the project how this might manifest, as it depended to a great extent on the interest and existing digital skills of the community.
 
-Ultimately the project was not very successful in tying parts 1 and 2 together — but First Choice Homes Oldham did begin running some beginners digital skills workshops for local residents which are still ongoing, and will hopefully continue indefinitely. 
+Ultimately the project was not very successful in tying parts 1 and 2 together — but First Choice Homes Oldham did begin running some beginners digital skills workshops for local residents which are still ongoing, and will hopefully continue indefinitely.
 
-This blog focuses specifically on the ‘documenting’ aspect, which occurred at the final stage of the project. You can get a deeper look at the challenges we had on the ‘collection’ side of things in [*RAFTT Design Diary #2*](https://gfsc.studio/blog/2023/raftt-design-blog-2/)!
+This blog focuses specifically on the ‘documenting’ aspect, which occurred at the final stage of the project. You can get a deeper look at the challenges we had on the ‘collection’ side of things in [_RAFTT Design Diary #2_](https://gfsc.studio/blog/2023/raftt-design-blog-2/)!
 
 # Structuring the site
 
-In [*RAFTT Design Diary #1*](https://gfsc.studio/blog/2022/rafft-design-blog/) we had already started to consider the underlying structure of our final explorable online archive of content. We asked questions about the narrative flow of the site, and considered what would be the most appropriate interface for people to explore the gathered data. We ruled out ‘Pincushion maps’, mostly because we don’t like them ([see this article by studio founder Kim for more on that](https://cassowaryproject.org/visualising-qualitative-data-on-maps/)) but also because, given the data is concentrated in such a small area, it wouldn’t be relevant for this project.
+In [_RAFTT Design Diary #1_](https://gfsc.studio/blog/2022/rafft-design-blog/) we had already started to consider the underlying structure of our final explorable online archive of content. We asked questions about the narrative flow of the site, and considered what would be the most appropriate interface for people to explore the gathered data. We ruled out ‘Pincushion maps’, mostly because we don’t like them ([see this article by studio founder Kim for more on that](https://cassowaryproject.org/visualising-qualitative-data-on-maps/)) but also because, given the data is concentrated in such a small area, it wouldn’t be relevant for this project.
 
 We did talk about wanting to try and do something a bit more creative than a ‘timeline’, but — hey ho — a timeline is ultimately where we ended up.
 
 The main reason for using a timeline was the comparatively small quantity of content we were able to gather, compared to what we might have hoped. Although the quantity of content was relatively limited, what we had was distributed widely throughout the last century.
 
-We had been hoping to meet a fair number of former Towers residents and build up a rich tapestry of memory about life inside the buildings, spanning their five decades of use. What we actually ended up with was a smaller number of residents, few of whom actually lived inside the Towers themselves, but were instead in the very close surrounding neighbourhoods. A couple of these women had memories of the area reaching all the way back to the 1940s, long before the towers were built or even conceived. 
+We had been hoping to meet a fair number of former Towers residents and build up a rich tapestry of memory about life inside the buildings, spanning their five decades of use. What we actually ended up with was a smaller number of residents, few of whom actually lived inside the Towers themselves, but were instead in the very close surrounding neighbourhoods. A couple of these women had memories of the area reaching all the way back to the 1940s, long before the towers were built or even conceived.
 
-We realised that a timeline structure would offer the best way of visualising the area’s rich history both *before* and *after* the towers arrived, and this time-based ‘split’ was something I was keen to emphasise in the design of the site. 
+We realised that a timeline structure would offer the best way of visualising the area’s rich history both _before_ and _after_ the towers arrived, and this time-based ‘split’ was something I was keen to emphasise in the design of the site.
 
 We also mentioned in the first design journal that we were excited by the idea of shaping the site around ‘themes’. We have offered theme filtering in the final site, but this is a secondary navigation device, as ultimately the themes which emerged from the stories were a tad less evocative than we might have hoped. For example, ‘Deprivation and Challenges’ wasn’t really something FCHO were keen to go into too much depth on. The themes serve more as a navigational tool (e.g. ‘I want to read a particular person’s stories’, or ‘I only want to read stories about the surrounding estate’) rather than the rich seams of connection we had hoped for.
 
@@ -47,7 +48,7 @@ Despite this end-stage pressure, as a designer I had of course been thinking for
 
 # Towers and clouds
 
-One of the most exciting design decisions for me was how to differentiate between the ‘before the towers’ and ‘after the towers’ phases. I had a silly idea while falling asleep one night of creating an ‘infinite scroll’ illustration of the Towers, so as you move down the site, you can see these (very tall) versions of the buildings in the background. I wasn’t sure whether to pursue it or not, but, unprompted, one of our dev team told me he’d had the same idea, so I decided to push ahead with it! 
+One of the most exciting design decisions for me was how to differentiate between the ‘before the towers’ and ‘after the towers’ phases. I had a silly idea while falling asleep one night of creating an ‘infinite scroll’ illustration of the Towers, so as you move down the site, you can see these (very tall) versions of the buildings in the background. I wasn’t sure whether to pursue it or not, but, unprompted, one of our dev team told me he’d had the same idea, so I decided to push ahead with it!
 
 It proved surprisingly difficult to create a totally seamless version of the illustration — so don’t look too close, okay 🙂! You’ll see that the Towers appear during the 1970s, when they were actually constructed.
 
@@ -67,23 +68,23 @@ The only other example I could readily bring to mind was this classic old shop s
 
 ![H. STAIN LTD Jewellers, prominently displaying signage in the same kind of font to the Royal Festival Hall. Some parts of the image are blurred as it’s a screenshot from Google streetview. ](h_stain.png)
 
-I spent some time attempting to figure out what typeface this was, and with help from the GFSC collective and my own design networks, we established that the closest match was Clarendon URW Bold Oblique. 
+I spent some time attempting to figure out what typeface this was, and with help from the GFSC collective and my own design networks, we established that the closest match was Clarendon URW Bold Oblique.
 
 I have a license to use this typeface to create graphics, but unfortunately it is not cheap or easy to get a web licence. As we try and build our sites to have a long life, and the only options for licensing Clarendon were rolling subscriptions (based on number of page views), we used a flat graphic for the main titles of the site and added alt text for accessibility and SEO. This felt like a bit of a hack, but there was nothing else quite like Clarendon and particularly nothing we could easily license!
 
 For the remainder of the site’s typography I have used Roboto Slab, a classic slab serif which crucially is a Google font, so licensing isn’t an issue!.
 
-In terms of colours, I wanted the palette to feel like it fitted with the Clarendon typeface. For the filters you’ll see I’ve used a similar blue to the Royal Festival Hall, and also pulled in some other slightly ‘dirty’ versions of various brights — to both differentiate clearly between the themes but still feel broadly in keeping with the overall 70s style. 
+In terms of colours, I wanted the palette to feel like it fitted with the Clarendon typeface. For the filters you’ll see I’ve used a similar blue to the Royal Festival Hall, and also pulled in some other slightly ‘dirty’ versions of various brights — to both differentiate clearly between the themes but still feel broadly in keeping with the overall 70s style.
 
 For the main colour of the site, perhaps controversially, I’ve gone with this lovely (?) mustard yellow or ‘baby poo’, as one of our devs less charitably put it 😂. I think this is an under-appreciated hue and one which speaks very strongly to me of municipal buildings, signage, furniture, fashion and more from the 1970s.
 
 ![A mustard coloured chair with wooden legs in the ‘mid century modern’ style](chair.png)
 
-*For just £477 you can buy this chair based edition of the site: https://www.etsy.com/uk/listing/698082102/mid-century-mustard-yellow-armchair-b310*
+_For just £477 you can buy this chair based edition of the site: https://www.etsy.com/uk/listing/698082102/mid-century-mustard-yellow-armchair-b310_
 
 ![David Bowie in a mustard coloured suit, sitting on a chair, holding some scissors](david_bowie.png)
 
-*David Bowie knew what was up https://www.theguardian.com/fashion/2013/mar/12/david-bowie-eight-classic-looks-pictures*
+_David Bowie knew what was up https://www.theguardian.com/fashion/2013/mar/12/david-bowie-eight-classic-looks-pictures_
 
 # Accessibility
 
@@ -91,19 +92,19 @@ We are always mindful of accessibility in our site design, and strive to meet at
 
 Another aspect of accessibility which we particularly cared about was clarity of navigation for those who might be new to the internet. Several of our ‘storytellers’ made clear that they had little interest in going online, or that they were daunted by it – which was part of the motivation behind the aforementioned digital skills workshops. We wanted to make sure that were any of these people to visit their local library to get online and visit the site, they would have the best possible chance of using and understanding it.
 
-For some people who are new to the internet  functionality that is very much taken for granted (like scrolling) can be new and unknown.  It is of course hard to avoid this, but I tried to design the site in such a way that, at its most basic level, little other than scrolling is required from the user. 
+For some people who are new to the internet functionality that is very much taken for granted (like scrolling) can be new and unknown. It is of course hard to avoid this, but I tried to design the site in such a way that, at its most basic level, little other than scrolling is required from the user.
 
-One common feature of modern websites (particularly ones with similar themes to ours) is a design which focusses on big splashy images, and hiding copy behind clickable pop-ups or drop-downs. One key principle I designed to was to ensure that all copy is visible. As a designer it is easy to be lured in by  big, beautiful image montages and fancy effects like parallax scroll and pop-ups, but we have steered clear of all of that here. As well as impacting the accessibility for those who don’t know to click through, sites with a lot of moving parts pose an issue for many people with vestibular dysfunction, who are susceptible to things like migraines or motion sickness. 
+One common feature of modern websites (particularly ones with similar themes to ours) is a design which focusses on big splashy images, and hiding copy behind clickable pop-ups or drop-downs. One key principle I designed to was to ensure that all copy is visible. As a designer it is easy to be lured in by big, beautiful image montages and fancy effects like parallax scroll and pop-ups, but we have steered clear of all of that here. As well as impacting the accessibility for those who don’t know to click through, sites with a lot of moving parts pose an issue for many people with vestibular dysfunction, who are susceptible to things like migraines or motion sickness.
 
-The site opens with a clear summary of what the project is, and a prompt to simply scroll, as well as mentioning the filters for those who want them. Users who are initially daunted by the filters or do not understand them can ignore that aspect entirely and just view the whole site. 
+The site opens with a clear summary of what the project is, and a prompt to simply scroll, as well as mentioning the filters for those who want them. Users who are initially daunted by the filters or do not understand them can ignore that aspect entirely and just view the whole site.
 
-Those who wish to explore using the filters have the option of browsing by either contributor or type of content. For slightly more advanced users, there is a ‘+’ to the top right which, when clicked, offers a handy navigation tool to jump to different decades in the timeline. 
+Those who wish to explore using the filters have the option of browsing by either contributor or type of content. For slightly more advanced users, there is a ‘+’ to the top right which, when clicked, offers a handy navigation tool to jump to different decades in the timeline.
 
 My only slight regret is that in order to turn off a filter you have to scroll back up to the top. I wanted a sticky header that stayed with you as you scrolled offering a ‘close’ function, but this caused issues on mobile, so we had to avoid it. This makes the filters slightly less user friendly than I would have liked, but still hopefully on balance a worthwhile feature.
 
-We also realised that we would need to build in some pop-ups specifically for the images on the site. We got some lovely archival photography and old album photos from some of our contributors, and needed to strike the balance between not making the site an *incredibly* long scroll (by putting all the images directly into the timeline at full size), and not making it too confusing by requiring the user to click too much.
+We also realised that we would need to build in some pop-ups specifically for the images on the site. We got some lovely archival photography and old album photos from some of our contributors, and needed to strike the balance between not making the site an _incredibly_ long scroll (by putting all the images directly into the timeline at full size), and not making it too confusing by requiring the user to click too much.
 
-Hopefully the little magnifying glasses in the corner of the clouds make clear to any user that they can view the images bigger, and the lightbox is of a sufficiently simple design that any user would easily be able to close them and return to the main scroll. 
+Hopefully the little magnifying glasses in the corner of the clouds make clear to any user that they can view the images bigger, and the lightbox is of a sufficiently simple design that any user would easily be able to close them and return to the main scroll.
 
 One of our devs did reflect to me that modals (pop-ups) like the lightboxes are really complex for screen readers to parse, and as he was considering that aspect of accessibility in the build, it did prove challenging. He said he’d prefer to avoid building them in future if possible, so this is certainly something for me to reflect on when designing future sites. How can we achieve a balanced flow of image and text, and get to the highest possible level of user accessibility?
 
@@ -113,8 +114,8 @@ One of our devs did reflect to me that modals (pop-ups) like the lightboxes are 
 
 Overall this has been a challenging but fascinating project from start to finish. It was the first project I worked on at GFSC, and that is unfortunately a slightly damning indictment of how far behind schedule it ended up falling — I have now been working here for two years!
 
-Most of these issues are due to the challenges we faced gathering content (as documented in [*RAFTT Design Diary #2*](https://gfsc.studio/blog/2023/raftt-design-blog-2/)), which were broadly out of our hands, but reflecting on the process from our end, I think it would have been helpful to start designing earlier. Even though designing without content to work with is challenging, and we didn’t want to define the final shape of the site until we understood everything we were working with, it may still have been better to take that risk and rushed less towards the end.
+Most of these issues are due to the challenges we faced gathering content (as documented in [_RAFTT Design Diary #2_](https://gfsc.studio/blog/2023/raftt-design-blog-2/)), which were broadly out of our hands, but reflecting on the process from our end, I think it would have been helpful to start designing earlier. Even though designing without content to work with is challenging, and we didn’t want to define the final shape of the site until we understood everything we were working with, it may still have been better to take that risk and rushed less towards the end.
 
 The site has been built for a long lifespan — the lottery funding is contingent on it remaining live for five years, but we have tried to ensure it will have a life beyond this timeframe, as we do with all static sites we build.
 
-Mostly it has just been a pleasure to get to know this community and its varied history. I would have loved if we could have accessed more of that history, but what we have managed to gather  here is far more than would have been secured otherwise. It’s my hope that this site will be stumbled across by many more curious Oldham residents in the years to come.
+Mostly it has just been a pleasure to get to know this community and its varied history. I would have loved if we could have accessed more of that history, but what we have managed to gather here is far more than would have been secured otherwise. It’s my hope that this site will be stumbled across by many more curious Oldham residents in the years to come.

--- a/content/blog/2023/raftt-design-diary-3/index.md
+++ b/content/blog/2023/raftt-design-diary-3/index.md
@@ -7,7 +7,8 @@ author: emma, honor, rebecca
 illustrator: emma
 social: cover.jpg
 aliases: /raftt-design-blog-3
-project: the-towers
+projects:
+  - the-towers
 ---
 
 {{<image src="cover.jpg" alt="A black and white shot of two towers at a junction with colourful writing across it reading 'The Towers' and 'A history of Summervale and Crossbank'">}}

--- a/themes/gfsc/layouts/partials/relatedblogs.html
+++ b/themes/gfsc/layouts/partials/relatedblogs.html
@@ -1,0 +1,14 @@
+{{ $key := index   ( split .RelPermalink  "/" ) 2 }}
+{{ $blogs := where .Site.RegularPages "Section" "blog" }}
+{{ $related := where $blogs ".Params.project" $key }}
+{{ with $related }}
+  <ul>
+    {{ range $related }}
+      <li>
+        <a href="{{ .Permalink }}">
+          {{ .Title }}
+        </a>
+      </li>
+    {{ end }}
+  </ul>
+{{ end }}

--- a/themes/gfsc/layouts/partials/relatedblogs.html
+++ b/themes/gfsc/layouts/partials/relatedblogs.html
@@ -1,6 +1,12 @@
 {{ $key := index   ( split .RelPermalink  "/" ) 2 }}
 {{ $blogs := where .Site.RegularPages "Section" "blog" }}
-{{ $related := where $blogs ".Params.project" $key }}
+{{ $related := slice }}
+{{ range $blogs }}
+  {{ if in .Params.Projects $key }}
+    {{ $related = $related | append . }}
+  {{ end }}
+{{ end }}
+
 {{ with $related }}
   <ul>
     {{ range $related }}


### PR DESCRIPTION
preparatory work towards #173

## Description

- add the project specific path to a blogs front matter eg https://gfsc.studio/project/the-towers/ -> `project: the-towers`
- add the partial to project layout template `{{- partial "relatedblogs.html" . -}}`
- it will produce a `ul` of related blogs if any exist or nothing.
- not rendering anywhere as of yet because we lack design. I've added it here near the top of a project to screenshot it to prove it's working.

![towers_related_blogs](https://github.com/geeksforsocialchange/gfsc-v3/assets/6824891/c998cdd4-a120-4923-9fc3-6c78df5496a5)



@geeksforsocialchange/developers
