### PR TITLE
Add publications tag

### DIFF
--- a/content/our-work/category/publications.md
+++ b/content/our-work/category/publications.md
@@ -1,0 +1,5 @@
+---
+title: "Publications"
+key: "publications"
+url: "/our-work/publications/"
+---


### PR DESCRIPTION
Fixes #351

## Description

- Adds new category.tag for publications
- Displays only when content is tagged with this so safe to merge

@geeksforsocialchange/developers
