### PR TITLE
Move tags to bottom of project page

### DIFF
--- a/themes/gfsc/assets/sass/components/_theme-tags.sass
+++ b/themes/gfsc/assets/sass/components/_theme-tags.sass
@@ -1,14 +1,8 @@
 .theme-tags
   display: flex
   flex-wrap: wrap
+  font-weight: 400
   gap: 0.5rem
-  font-size: 1rem
-  font-weight: 900
-  &__list
-    display: flex
-    flex-wrap: wrap
-    font-weight: 400
-    gap: 0.5rem
-    list-style: none
-    margin: 0
-    padding: 0
+  list-style: none
+  margin: 0
+  padding: 0

--- a/themes/gfsc/assets/sass/components/_theme-tags.sass
+++ b/themes/gfsc/assets/sass/components/_theme-tags.sass
@@ -1,8 +1,14 @@
 .theme-tags
-  list-style: none
-  margin: 0
-  padding: 0
   display: flex
   flex-wrap: wrap
   gap: 0.5rem
   font-size: 1rem
+  font-weight: 900
+  &__list
+    display: flex
+    flex-wrap: wrap
+    font-weight: 400
+    gap: 0.5rem
+    list-style: none
+    margin: 0
+    padding: 0

--- a/themes/gfsc/assets/sass/pages/_project.sass
+++ b/themes/gfsc/assets/sass/pages/_project.sass
@@ -1,9 +1,9 @@
 .project
   +border(0 2px 2px 2px)
-  padding: 1.5rem 1rem 1rem 1rem
+  padding: 0 1rem
   +for-tablet-portrait-up
     +border(none)
-    padding: 2rem 5rem
+    padding: 0 5rem
   +for-desktop-up
     margin: 0 $margin-desktop
     +border(sides)
@@ -11,24 +11,26 @@
   .fancy
     margin: 0 -5rem
   &__title
-    margin-block-start: 0
-    margin-block-end: 0
-    padding-bottom: 1.5rem
     font-family: $freight
     font-size: 1.666666rem
     line-height: 1.1em
+    margin: 0 -1rem
+    padding: 1.5rem 1rem
+    +border(bottom)
     +for-tablet-portrait-up
       font-size: 2.222222rem
-      padding-bottom: 2rem
+      margin: 0 -5rem
+      padding: 2rem 5rem
   &__themes
-    +border(nosides)
+    +border(top)
     margin: 0 -1rem
-    padding: 1rem  1rem
+    padding: 1rem 1rem
     +for-tablet-portrait-up
       margin: 0 -5rem
-      padding: 1rem  5rem
+      padding: 1rem 5rem
   &__summary
     font-weight: 900
+    margin: 1.444444rem 0
     +for-tablet-portrait-up
       font-weight: normal
       font-size: 1.444444rem
@@ -60,7 +62,7 @@
     &__team
       +border(top)
       grid-row: 2 / 3
-      grid-column: 1 / 3   
+      grid-column: 1 / 3
       +for-tablet-landscape-up
         padding-left: 5rem
       +for-desktop-up
@@ -74,6 +76,9 @@
         color: $primary
         margin: 0 0.25rem
   &__content
+    padding-bottom: 1.5rem
+    +for-tablet-portrait-up
+      padding: 2rem 0
     ul
       list-style-type: none
       margin: 2rem 0

--- a/themes/gfsc/assets/sass/pages/_project.sass
+++ b/themes/gfsc/assets/sass/pages/_project.sass
@@ -23,6 +23,11 @@
       padding: 2rem 5rem
   &__themes
     +border(top)
+    display: flex
+    flex-wrap: wrap
+    gap: 0.5rem
+    font-size: 1rem
+    font-weight: 900
     margin: 0 -1rem
     padding: 1rem 1rem
     +for-tablet-portrait-up

--- a/themes/gfsc/layouts/partials/themeTags.html
+++ b/themes/gfsc/layouts/partials/themeTags.html
@@ -5,22 +5,23 @@
 {{ end }}
 
 {{ $projectThemes := split .Params.themes " " }}
-
-
-<ul role="list" class="theme-tags">
-  {{ range $index, $val := $projectThemes }}
-    {{ if ( ge   (add $index 1 ) ( len $projectThemes )) }}
-      <li>
-        <a href=" {{ (index $themes $val).link }} ">
-          {{ (index $themes $val).title }}
-        </a>
-      </li>
-    {{ else }}
-      <li>
-        <a href=" {{ (index $themes $val).link }} ">
-          {{ (index $themes $val).title }},
-        </a>
-      </li>
+<div class="theme-tags">
+  <span>See more:</span>
+  <ul role="list" class="theme-tags__list">
+    {{ range $index, $val := $projectThemes }}
+      {{ if ( ge   (add $index 1 ) ( len $projectThemes )) }}
+        <li>
+          <a href=" {{ (index $themes $val).link }} ">
+            {{ (index $themes $val).title }}
+          </a>
+        </li>
+      {{ else }}
+        <li>
+          <a href=" {{ (index $themes $val).link }} ">
+            {{ (index $themes $val).title }},
+          </a>
+        </li>
+      {{ end }}
     {{ end }}
-  {{ end }}
-</ul>
+  </ul>
+</div>

--- a/themes/gfsc/layouts/partials/themeTags.html
+++ b/themes/gfsc/layouts/partials/themeTags.html
@@ -5,23 +5,20 @@
 {{ end }}
 
 {{ $projectThemes := split .Params.themes " " }}
-<div class="theme-tags">
-  <span>See more:</span>
-  <ul role="list" class="theme-tags__list">
-    {{ range $index, $val := $projectThemes }}
-      {{ if ( ge   (add $index 1 ) ( len $projectThemes )) }}
-        <li>
-          <a href=" {{ (index $themes $val).link }} ">
-            {{ (index $themes $val).title }}
-          </a>
-        </li>
-      {{ else }}
-        <li>
-          <a href=" {{ (index $themes $val).link }} ">
-            {{ (index $themes $val).title }},
-          </a>
-        </li>
-      {{ end }}
+<ul role="list" class="theme-tags">
+  {{ range $index, $val := $projectThemes }}
+    {{ if ( ge   (add $index 1 ) ( len $projectThemes )) }}
+      <li>
+        <a href=" {{ (index $themes $val).link }} ">
+          {{ (index $themes $val).title }}
+        </a>
+      </li>
+    {{ else }}
+      <li>
+        <a href=" {{ (index $themes $val).link }} ">
+          {{ (index $themes $val).title }},
+        </a>
+      </li>
     {{ end }}
-  </ul>
-</div>
+  {{ end }}
+</ul>

--- a/themes/gfsc/layouts/project/single.html
+++ b/themes/gfsc/layouts/project/single.html
@@ -38,10 +38,11 @@
 		{{end}}
 	</div>
   {{ if .Params.themes }}
-		<div class="project__themes">
-			{{- partial "themeTags.html" . -}}
-		</div>
-	{{ end }}
+    <div class="project__themes">
+      <span>See more:</span>
+      {{- partial "themeTags.html" . -}}
+    </div>
+  {{ end }}
   {{/* 
     <div class="project__footer">
       <div>

--- a/themes/gfsc/layouts/project/single.html
+++ b/themes/gfsc/layouts/project/single.html
@@ -1,11 +1,6 @@
 {{ define "main" }}
 <div class="project">
   <h3 class="project__title">{{ .Title }}</h3>
-	{{ if .Params.themes }}
-		<div class="project__themes">
-			{{- partial "themeTags.html" . -}}
-		</div>
-	{{ end }}
   <p class="project__summary">
 		{{ .Description }}
 	</p>
@@ -42,6 +37,11 @@
 			</a>
 		{{end}}
 	</div>
+  {{ if .Params.themes }}
+		<div class="project__themes">
+			{{- partial "themeTags.html" . -}}
+		</div>
+	{{ end }}
   {{/* 
     <div class="project__footer">
       <div>


### PR DESCRIPTION
Fixes 352

## Description

- Moves tags to the bottom of the project page, directly under content
- Adds descriptive 'see more' text to the start of the tags list

@geeksforsocialchange/developers
