### PR TITLE
pdfs from the pubblications CTA section download and open in new window

### DIFF
--- a/themes/gfsc/layouts/partials/ctabuttons.html
+++ b/themes/gfsc/layouts/partials/ctabuttons.html
@@ -1,7 +1,13 @@
 {{ with . }}
   <div class="cta-buttons">
     {{ range . }}
-      <a class="btn" href="{{ .url }}">
+      <a
+        class="btn"
+        href="{{ .url }}"
+        {{ if in .url "pdf" }}
+          target="_blank" download
+        {{ end }}
+      >
         {{ .text }}
       </a>
     {{ end }}


### PR DESCRIPTION
Fixes #355 

## Description

- checks url for `pdf` and inserts a download/target attribute to the link.
- doesn't deal with other file types, not specified by the issue but something to be aware of.

@geeksforsocialchange/developers
