### PR TITLE
Feat/363 add projects to blogs

### DIFF
--- a/content/blog/2017/tech-culture-failing-communities/index.md
+++ b/content/blog/2017/tech-culture-failing-communities/index.md
@@ -12,6 +12,8 @@ description:
 social: og-wide.png
 subtitle: We need a roadmap towards truly community-owned technology.
 title: Tech culture is failing communities. How can we make it better?
+projects:
+  - placecal
 ---
 
 Californian design principles have taken over the internet, turning people into products. We need a roadmap towards truly community-owned technology.

--- a/content/blog/2018/placecal-story-so-far/index.md
+++ b/content/blog/2018/placecal-story-so-far/index.md
@@ -10,6 +10,8 @@ description:
   recap the process so far.
 subtitle: Creating a low social capital social network for Manchester.
 title: "PlaceCal: The Story So Far"
+projects:
+  - placecal
 ---
 
 I’ve spent the last 9 months working with PHASE@MMU, Smart City project CityVerve, and Manchester City Council to deliver [PlaceCal](https://placecal.org/), a crowd-sourced community events calendar. It’s been an extremely busy time with a lot of learning in a very short amount of time, and as we head into Phase 2 of our development I thought it’d be a good time to recap the process so far.

--- a/content/blog/2018/placecal-story-so-far/index.md
+++ b/content/blog/2018/placecal-story-so-far/index.md
@@ -12,6 +12,8 @@ subtitle: Creating a low social capital social network for Manchester.
 title: "PlaceCal: The Story So Far"
 projects:
   - placecal
+  - hulme-history
+  - hulme-community-garden-centre
 ---
 
 I’ve spent the last 9 months working with PHASE@MMU, Smart City project CityVerve, and Manchester City Council to deliver [PlaceCal](https://placecal.org/), a crowd-sourced community events calendar. It’s been an extremely busy time with a lot of learning in a very short amount of time, and as we head into Phase 2 of our development I thought it’d be a good time to recap the process so far.

--- a/content/blog/2019/brief-introduction-placecal/index.md
+++ b/content/blog/2019/brief-introduction-placecal/index.md
@@ -8,6 +8,8 @@ description:
   in their community by connecting them to events that are happening nearby.
 subtitle: How we made Hulme & Moss Side's go-to resource to find out what's on.
 title: A brief introduction to PlaceCal
+projects:
+  - placecal
 ---
 
 PlaceCal is a package of calendar software, education and community development. It makes it easier for residents to publish events, find information about their area, and see how to get involved in local groups. This helps people become active in their community by connecting them to events that are happening nearby. The result of this is a more connected neighbourhood that works better for everyone.

--- a/content/blog/2019/brief-introduction-placecal/index.md
+++ b/content/blog/2019/brief-introduction-placecal/index.md
@@ -10,6 +10,10 @@ subtitle: How we made Hulme & Moss Side's go-to resource to find out what's on.
 title: A brief introduction to PlaceCal
 projects:
   - placecal
+  - hulme-history
+  - hulme-community-garden-centre
+  - mossley-history
+  - oldham-history
 ---
 
 PlaceCal is a package of calendar software, education and community development. It makes it easier for residents to publish events, find information about their area, and see how to get involved in local groups. This helps people become active in their community by connecting them to events that are happening nearby. The result of this is a more connected neighbourhood that works better for everyone.

--- a/content/blog/2019/ladder-citizen-participation/index.md
+++ b/content/blog/2019/ladder-citizen-participation/index.md
@@ -9,6 +9,8 @@ description:
 subtitle: Revisiting Arnstein's "Ladder of Citizen Participation"
 title: Why tech co-production practice is barely scratching the surface
 alias: ladder_citizen_participation
+projects:
+  - placecal
 ---
 
 There's a lot of discussion about co-production, co-design and other impressive-sounding terms starting with 'co-' at the moment in tech[^tech] circles. These terms long predate tech and generally have their roots in urban planning and civic policy. Despite all the hip methodologies such as 'service mapping' and 'human centred design', many in tech seem to miss the original point of these methodologies: _to give complete power to the community that work is being done 'on behalf' of_. In other words, there's nothing special about any design methodology. Change happens when the balance of power is shifted, otherwise it's just potentially well done and engaged market research.

--- a/content/blog/2019/placecal-capabilities-approach/index.md
+++ b/content/blog/2019/placecal-capabilities-approach/index.md
@@ -8,6 +8,8 @@ description:
   to social participation and collaborative action.
 subtitle: PlaceCal and the capabilities approach
 title: Making a place for technology in communities
+projects:
+  - placecal
 ---
 
 _This post is a draft of a journal paper by Prof. Stefan White and I on our application of the capability approach to community technology in Hulme and Moss Side. We're hoping it will be published next year, in the mean time please let us know if you have any thoughts on the draft! If you prefer, you can download it in [pdf form.](/assets/pdf/WhiteFoale_PlaceCal-Capabilities_DRAFT.pdf)_

--- a/content/blog/2020/manchester-community-histories-urban-regeneration/index.md
+++ b/content/blog/2020/manchester-community-histories-urban-regeneration/index.md
@@ -8,6 +8,10 @@ description:
 social: og-wide.jpg
 subtitle: A report on our community history day in November 2019
 title: Manchester Community Histories in the Shadow of Urban Regeneration
+projects:
+  - hulme-history
+  - hulme-community-garden-centre
+  - taphouse-tv-dinners
 ---
 
 On a chilly Saturday morning last November I joined other local residents, activists and researchers to participate in the first [Hulme &amp; Greenheys Community History Day](/blog/2019/hulme-greenheys-history-day) in Manchester. The event was held in the historic [Old Abbey Taphouse](http://www.theoldabbeytaphouse.co.uk/), one of the few nineteenth-century institutions to have survived the multiple waves of state-led ‘urban regeneration’ that have irrevocably transformed the area over the past sixty years. Organised by the pub's co-director Rachele Evaroa in partnership with Kim Foale, founder of local tech enterprise Geeks for Social Change, the day’s activities were designed to bring people together to share firsthand accounts of life in the old neighbourhood as well as foster dialogue about the impact of city planning and urban regeneration initiatives on local communities – then and now.

--- a/content/blog/2021/enter-trans-dimension/index.md
+++ b/content/blog/2021/enter-trans-dimension/index.md
@@ -8,6 +8,8 @@ description:
 social: transdimension.png
 subtitle: A new space for trans community enabled by technology and collaboration.
 title: Enter... The Trans Dimension!
+projects:
+  - trans-dimension
 ---
 
 {{<image src="transdimension.png" alt="Promo artwork for The Trans Dimension. It's an illustration of outer space. The foreground has five figures of a range of ages, genders and abilities waving trans flags and reading books. The background has trans-shaped constellations, space worms, rockets, nebulas and planets.">}}

--- a/content/blog/2021/everything-is-connected/index.md
+++ b/content/blog/2021/everything-is-connected/index.md
@@ -7,6 +7,8 @@ description:
 social: og-wide.png
 subtitle: What if storing user data at all is a dark pattern?
 title: Everything is connected, but should it be?
+projects:
+  - resistance-lab
 ---
 
 Content note: This article contains discussions of classism, police brutality, incarceration, sexism & misogyny, forced deportation and racism, with brief mentions of rape, violence, blood & needles, death and genocide.[^2]

--- a/content/blog/2021/imok-is-launched/index.md
+++ b/content/blog/2021/imok-is-launched/index.md
@@ -7,6 +7,8 @@ description:
   other vulnerable groups.
 subtitle: A simple bot designed to support people undertaking potentially risky activities
 title: imok is released!
+projects:
+  - imok
 ---
 
 imok is a simple bot designed to support people undertaking potentially risky activities. It's primarily aimed at community groups working together to support these people.

--- a/content/blog/2022/gfsc-2021-roundup/index.md
+++ b/content/blog/2022/gfsc-2021-roundup/index.md
@@ -12,6 +12,7 @@ projects:
   - placecal
   - trans-dimension
   - imok
+  - resistance-lab
 ---
 
 For now though, here’s some of our 2021 highlights!

--- a/content/blog/2022/gfsc-2021-roundup/index.md
+++ b/content/blog/2022/gfsc-2021-roundup/index.md
@@ -8,6 +8,8 @@ description:
 social: transdimension.png
 subtitle: A roundup of what we did last year
 title: GFSC 2021 Roundup
+projects:
+  - placecal
 ---
 
 For now though, here’s some of our 2021 highlights!

--- a/content/blog/2022/gfsc-2021-roundup/index.md
+++ b/content/blog/2022/gfsc-2021-roundup/index.md
@@ -11,6 +11,7 @@ title: GFSC 2021 Roundup
 projects:
   - placecal
   - trans-dimension
+  - imok
 ---
 
 For now though, here’s some of our 2021 highlights!

--- a/content/blog/2022/gfsc-2021-roundup/index.md
+++ b/content/blog/2022/gfsc-2021-roundup/index.md
@@ -13,6 +13,10 @@ projects:
   - trans-dimension
   - imok
   - resistance-lab
+  - growing-threat-to-life
+  - enquiry-witch
+  - faceloader
+  - gi-website-migration
 ---
 
 For now though, here’s some of our 2021 highlights!

--- a/content/blog/2022/gfsc-2021-roundup/index.md
+++ b/content/blog/2022/gfsc-2021-roundup/index.md
@@ -10,6 +10,7 @@ subtitle: A roundup of what we did last year
 title: GFSC 2021 Roundup
 projects:
   - placecal
+  - trans-dimension
 ---
 
 For now though, here’s some of our 2021 highlights!

--- a/content/blog/2022/national-network-community-technology-partnerships/index.md
+++ b/content/blog/2022/national-network-community-technology-partnerships/index.md
@@ -5,6 +5,8 @@ subtitle: How we are going to transform the relationships between people, techno
 description: Working in an ambitious partnership with C2 Connecting Communities, Manchester School of Architecture, The Wellcome Centre for Cultures and Environments of Health, and half a dozen friends and allies, have collectively won £220,000 from the largest funder of community activity in the UK.
 author: kim
 social: PlaceCal_16by9_LocalArea.png
+projects:
+  - placecal
 ---
 
 {{<image src="PlaceCal_16by9_LocalArea.png" alt="An illustration of a community of place" classList="image--frame">}}

--- a/content/blog/2022/rise-fall-facebook-events/index.md
+++ b/content/blog/2022/rise-fall-facebook-events/index.md
@@ -8,6 +8,7 @@ social: 2.jpg
 aliases: /podcast/2
 projects:
   - placecal
+  - faceloader
 ---
 
 {{<anchorfm "The-Rise-and-Fall-of-Facebook-Events-e1onssn" >}}

--- a/content/blog/2022/rise-fall-facebook-events/index.md
+++ b/content/blog/2022/rise-fall-facebook-events/index.md
@@ -6,6 +6,8 @@ description: David Hayward and Rachele Evaroa join Kim to talk about the infiltr
 author: kim
 social: 2.jpg
 aliases: /podcast/2
+projects:
+  - placecal
 ---
 
 {{<anchorfm "The-Rise-and-Fall-of-Facebook-Events-e1onssn" >}}

--- a/content/blog/2022/trans-dimension-accessibility-guide/index.md
+++ b/content/blog/2022/trans-dimension-accessibility-guide/index.md
@@ -5,6 +5,8 @@ subtitle: A first look at our new zine on making events more inclusive for every
 description: "When we asked our collaborators for affirming or positive experiences they’ve had at events we heard “the best I've had is mediocre.” We want to believe that this is not because of a lack of understanding and responsibility, but for a lack of guidance and resources."
 author: kim
 social: transdimension.png
+projects:
+  - trans-dimension
 ---
 
 {{<image src="transdimension.png" alt="Promo artwork for The Trans Dimension. It's an illustration of outer space. The foreground has five figures of a range of ages, genders and abilities waving trans flags and reading books. The background has trans-shaped constellations, space worms, rockets, nebulas and planets.">}}

--- a/content/blog/2023/everything-we-want-to-tell-you/index.md
+++ b/content/blog/2023/everything-we-want-to-tell-you/index.md
@@ -6,6 +6,8 @@ description: In the third episode of the Geeks For Social Change podcast, Dr Kim
 author: honor
 social: 1.png
 aliases: /podcast/3
+projects:
+  - placecal
 ---
 
 {{<anchorfm "Everything-we-want-to-tell-you-about-your-funding-scheme-but-are-afraid-to-tell-you-e25lnko" >}}

--- a/content/blog/2023/everything-we-want-to-tell-you/index.md
+++ b/content/blog/2023/everything-we-want-to-tell-you/index.md
@@ -8,6 +8,7 @@ social: 1.png
 aliases: /podcast/3
 projects:
   - placecal
+  - trans-dimension
 ---
 
 {{<anchorfm "Everything-we-want-to-tell-you-about-your-funding-scheme-but-are-afraid-to-tell-you-e25lnko" >}}

--- a/content/project/resistance-lab/index.md
+++ b/content/project/resistance-lab/index.md
@@ -12,7 +12,7 @@ image:
 imagealt:
 description: "How we worked with Resistance Lab from the start to build their first website and support them with branding and design"
 weight: 2
-draft: true
+draft: false
 ---
 
 Resistance lab is a multi-disciplinary team of activists, campaigners and researchers who are aiming to dismantle the causes of state violence. Resistance Lab was formed in Manchester in 2019, and its members regularly meet to discuss and organise research work that will raise awareness about different forms of state violence, and to support other groups working on those same aims, in Manchester and across the UK.

--- a/content/project/resistance-lab/index.md
+++ b/content/project/resistance-lab/index.md
@@ -12,7 +12,7 @@ image:
 imagealt:
 description: "How we worked with Resistance Lab from the start to build their first website and support them with branding and design"
 weight: 2
-draft: false
+draft: true
 ---
 
 Resistance lab is a multi-disciplinary team of activists, campaigners and researchers who are aiming to dismantle the causes of state violence. Resistance Lab was formed in Manchester in 2019, and its members regularly meet to discuss and organise research work that will raise awareness about different forms of state violence, and to support other groups working on those same aims, in Manchester and across the UK.

--- a/themes/gfsc/layouts/partials/blogTeaser.html
+++ b/themes/gfsc/layouts/partials/blogTeaser.html
@@ -1,6 +1,7 @@
 {{ $post := .post }}
 {{ $ctx := .ctx }}
 {{ $blogauthors := split $post.Params.Author ", " }}
+{{ $date := .post.Params.Date }}
 {{ $relatedClass := "" }}
 {{ if not (in $ctx.RelPermalink "/blog/" ) }}
   {{ $relatedClass =  "teaser__content--related" }}
@@ -34,8 +35,8 @@
     </div>
   </div>
   <aside class="teaser__aside">
-    <time class="teaser__meta" datetime="{{ .Date }}">
-      {{ .Date.Format "02 January 2006" }}
+    <time class="teaser__meta" datetime="{{ $date }}">
+      {{ $date.Format "02 January 2006" }}
     </time>
     <div class="teaser__meta teaser__meta--author" rel="author">
       {{ range $index, $authortag := $blogauthors }}


### PR DESCRIPTION
Fixes #363

## Description

- Fixes date presentational error on blog teasers on project pages
- Adds related blogs to projects wherever seemed appropriate. No doubt there are some missing and some that are only tangentially related but this is hopefully a good start!

@geeksforsocialchange/developers
