### PR TITLE
remove intense orange block on galery thumbnails

### DIFF
--- a/themes/gfsc/assets/sass/components/_gallery.sass
+++ b/themes/gfsc/assets/sass/components/_gallery.sass
@@ -10,15 +10,17 @@
   &__thumbnails
     display: flex
     justify-content: flex-start
-    flex-wrap: wrap
     background-color: $primary
-    img
-      height: 60px
+    gap: 0 2px
+    +border(bottom)
+    overflow: auto;
   &__thumbnail
     cursor: pointer
     line-height: 0
-    padding: 0 2px 2px 0
-    &--filler
-      width: auto
-      background-color: transparent
+    background-color: $secondary
+    height: 60px
+    aspect-ratio: 2 / 1
+  &__filler
+    flex-grow: 1
+    background-color: $secondary
       

--- a/themes/gfsc/layouts/partials/gallery.html
+++ b/themes/gfsc/layouts/partials/gallery.html
@@ -30,7 +30,7 @@
           </div>
         {{ end }}
       {{ end }}
-      <div class="gallery__thumbnail gallery__thumbnail--filler"></div>
+      <div class="gallery__filler"></div>
     </div>
   </div>
 {{ else }}


### PR DESCRIPTION
I started looking at #192 because it is one of the bugs that bothers me the most on the site.

I realized that I didn't have time to tackle what is a quite a complex problem but I've hopefully made some improvements.

## Description

- background of thumbnails is secondary so pngs with clear backgrounds aren't displayed on the bright orange.
- a flex item that expands to fill remaining space hides the orange background or collapses if not needed.

![image](https://github.com/geeksforsocialchange/gfsc-v3/assets/6824891/8f72e698-47da-4332-bea4-1d5c6819b4ee)

- if there are more thumbnails we overflow with scroll to avoid getting a small section of dead space on the right hand side of the top row and a large dead space on the bottom row.

https://github.com/geeksforsocialchange/gfsc-v3/assets/6824891/20408f2c-361a-4695-b259-87903f2006a3




@geeksforsocialchange/developers
