### PR TITLE
remove italics for legibility

### DIFF
--- a/themes/gfsc/assets/sass/components/_windows.sass
+++ b/themes/gfsc/assets/sass/components/_windows.sass
@@ -128,8 +128,6 @@
           margin: 1rem 1rem 1rem 0
         &:nth-child(even)
           margin: 1rem 0 1rem 1rem
-      &__content
-        font-style: italic
 
 .window
   +border(all)

--- a/themes/gfsc/assets/sass/pages/_work.sass
+++ b/themes/gfsc/assets/sass/pages/_work.sass
@@ -160,7 +160,6 @@
   &__content
     +border(topless)
     padding: 1rem
-    font-style: italic
     text-align: center
     +for-tablet-portrait-up
       +border(none)


### PR DESCRIPTION
Fixes #335 

## Description

- italics removed from the themes "windows" on the homepage
- italics removed from the descriptive paragraph at the top of each  theme/category page.

@geeksforsocialchange/developers
