### PR TITLE
Make 404 page funner

### DIFF
--- a/themes/gfsc/assets/sass/components/_venn.sass
+++ b/themes/gfsc/assets/sass/components/_venn.sass
@@ -184,7 +184,6 @@
   text
     text-anchor: middle
     alignment-baseline: middle
-    cursor: pointer
   .one text
     font-size: 2rem
     text-transform: uppercase

--- a/themes/gfsc/assets/sass/components/_venn.sass
+++ b/themes/gfsc/assets/sass/components/_venn.sass
@@ -54,6 +54,30 @@
       stroke-miterlimit: 10
       stroke-width: 2
 
+.venn-404
+  text-align: center
+  &__container
+    width: 100%
+    overflow: hidden
+  &__diagram
+    margin: 1rem 0
+    transform: translateX(-22%)
+    width: 180%
+    +for-tablet-portrait-up
+      margin: none
+      transform: none
+      width: 100%
+    path
+      fill: transparent
+    text
+      +balboa
+      fill: $primary
+    ellipse
+      fill: transparent
+      stroke: $primary
+      stroke-miterlimit: 10
+      stroke-width: 2
+
 #venn-mobile
   +for-tablet-portrait-up
     display: none
@@ -152,3 +176,17 @@
       fill: $primary-shadier
     &.three path
       fill: $primary-shadier
+
+#venn-404
+  max-width: 1300px
+  display: block
+  text-align: center
+  text
+    text-anchor: middle
+    alignment-baseline: middle
+    cursor: pointer
+  .one text
+    font-size: 2rem
+    text-transform: uppercase
+  .three text
+    font-size: 1.6rem

--- a/themes/gfsc/layouts/404.html
+++ b/themes/gfsc/layouts/404.html
@@ -1,5 +1,9 @@
 {{ define "main" }}
   <div class="homepage__themes">
+    <div class="screen-reader-only">
+      This page could not be found. Common causes include: deceased links,
+      overzealous autocorrect and ongoing witch-based curse.
+    </div>
     <div aria-hidden="true" class="venn-404__container">
       {{ partial "venn-404.html" . }}
     </div>

--- a/themes/gfsc/layouts/404.html
+++ b/themes/gfsc/layouts/404.html
@@ -1,5 +1,7 @@
 {{ define "main" }}
-<div class="homepage__themes">
-  <h2 class="venn__title">The page you are looking for does not exist.</h2>
-</div>
+  <div class="homepage__themes">
+    <div aria-hidden="true" class="venn-404__container">
+      {{ partial "venn-404.html" . }}
+    </div>
+  </div>
 {{ end }}

--- a/themes/gfsc/layouts/partials/venn-404.html
+++ b/themes/gfsc/layouts/partials/venn-404.html
@@ -1,0 +1,103 @@
+<svg
+  class="venn-404__diagram"
+  xmlns="http://www.w3.org/2000/svg"
+  viewBox="0 0 1300 670"
+  id="venn-404"
+>
+  <g class="diagram" transform="translate(245,-65)">
+    <g id="a" class="one">
+      <path
+        d="M274.11,295.8A235.66,235.66,0,0,1,400,96.75,234.31,234.31,0,0,0,290.57,69.81c-130,0-235.44,105.41-235.44,235.44a235.26,235.26,0,0,0,109.56,199A235.47,235.47,0,0,1,274.11,295.8Z"
+      />
+      <text id="text--left" transform="translate(183, 250)">
+        <tspan x="0em" y="0em">OVERZEALOUS</tspan>
+        <tspan x="0em" y="1em">AUTOCORRECT</tspan>
+      </text>
+    </g>
+    <g id="b" class="one">
+      <path
+        d="M627.11,101.35A235.29,235.29,0,0,0,400,96.74a235.46,235.46,0,0,1,125.8,199A235.6,235.6,0,0,1,635.24,504.26a234.44,234.44,0,0,0,78-81.3C778.3,310.36,739.72,166.37,627.11,101.35Z"
+      />
+      <text id="text--right" transform="translate(623, 250)">
+        <tspan x="0" y="0em">POCKET</tspan>
+        <tspan x="0" y="1em">BROWSING</tspan>
+      </text>
+    </g>
+    <g id="c" class="one">
+      <path
+        d="M400,513.72a235.65,235.65,0,0,1-235.33-9.48,234.34,234.34,0,0,0,31.39,108.23c65,112.61,209,151.19,321.61,86.18A235.25,235.25,0,0,0,635.24,504.27,235.42,235.42,0,0,1,400,513.72Z"
+      />
+      <text id="text--bottom" transform="translate(400, 615)">
+        <tspan x="0" y="0em">CURSED BY WITCH</tspan>
+        <tspan x="0" y="1em">ON BIRTHDAY</tspan>
+      </text>
+    </g>
+    <g id="ab" class="two">
+      <path
+        d="M282.26,290.86a235.38,235.38,0,0,1,243.55,4.87A235.42,235.42,0,0,0,400,96.75,235.66,235.66,0,0,0,274.11,295.8Q278.13,293.27,282.26,290.86Z"
+      />
+    </g>
+    <g id="bc" class="two">
+      <path
+        d="M603.88,377a234.49,234.49,0,0,0-78.08-81.32c.12,3.16.21,6.33.21,9.53A235.39,235.39,0,0,1,400,513.73a235.39,235.39,0,0,0,235.22-9.47A234.26,234.26,0,0,0,603.88,377Z"
+      />
+    </g>
+    <g id="ac" class="two">
+      <path
+        d="M391.67,509.14A235.42,235.42,0,0,1,274.11,295.79,235.42,235.42,0,0,0,164.7,504.24,235.65,235.65,0,0,0,400,513.72C397.23,512.25,394.44,510.74,391.67,509.14Z"
+      />
+    </g>
+    <g id="abc" class="three">
+      <path
+        d="M526,305.25c0-3.2-.09-6.37-.21-9.53a235.41,235.41,0,0,0-243.54-4.86q-4.14,2.4-8.15,4.94A235.4,235.4,0,0,0,391.67,509.14c2.77,1.6,5.56,3.11,8.36,4.58A235.38,235.38,0,0,0,526,305.25Z"
+      />
+      <text id="text--middle" transform="translate(400, 365)">
+        <tspan x="0" y="0em">Error 404:</tspan>
+        <tspan x="0" y="1em">page not found</tspan>
+      </text>
+    </g>
+    <circle
+      class="outline"
+      cx="399.98"
+      cy="494.75"
+      r="235.44"
+      style="
+        fill: none;
+        stroke: #ea5b0c;
+        stroke-miterlimit: 10;
+        stroke-width: 3px;
+      "
+    />
+    <path
+      d="M627.11,101.35A235.29,235.29,0,0,0,400,96.74a235.46,235.46,0,0,1,125.8,199A235.6,235.6,0,0,1,635.24,504.26a234.44,234.44,0,0,0,78-81.3C778.3,310.36,739.72,166.37,627.11,101.35Z"
+      style="
+        fill: none;
+        stroke: #ea5b0c;
+        stroke-miterlimit: 10;
+        stroke-width: 3px;
+      "
+    />
+    <circle
+      cx="509.39"
+      cy="305.25"
+      r="235.44"
+      style="
+        fill: none;
+        stroke: #ea5b0c;
+        stroke-miterlimit: 10;
+        stroke-width: 3px;
+      "
+    />
+    <circle
+      cx="290.57"
+      cy="305.25"
+      r="235.44"
+      style="
+        fill: none;
+        stroke: #ea5b0c;
+        stroke-miterlimit: 10;
+        stroke-width: 3px;
+      "
+    />
+  </g>
+</svg>


### PR DESCRIPTION
Fixes #293 

## Description

- Adds a venn diagram to our 404 page with silly reasons given for landing here
- Keeps the main title and adds error 404 to the centre to make sure it's clear still to all users what page this is
- Uses slightly different styling to homepage venn at mobile, to preserve look of diagram as descriptions not required

@geeksforsocialchange/developers
