### PR TITLE
Alias mailing-list to contact

### DIFF
--- a/content/contact/index.md
+++ b/content/contact/index.md
@@ -4,4 +4,6 @@ type: contact
 bigtext: Discover how we can work together towards a fairer world.
 notitle: true
 nostrip: true
+aliases:
+  - mailing-list
 ---


### PR DESCRIPTION
Fixes #380

## Description

- redirects visits to `https://gfsc.studio/mailing-list` to `https://gfsc.studio/contact` which displays email addresses and a signup link to the mailing list

@geeksforsocialchange/developers
