### PR TITLE
remove F and Rebecca from the team page

### DIFF
--- a/content/team/staff/f/index.md
+++ b/content/team/staff/f/index.md
@@ -3,7 +3,7 @@ title: "F"
 firstname: "F"
 pronouns: "ey/em or they/them"
 job: "Technology Strategy Consultant"
-jobtype: staff
+jobtype: alum
 dataname: f
 avatar: f@400.jpg
 ---

--- a/content/team/staff/rebecca/index.md
+++ b/content/team/staff/rebecca/index.md
@@ -3,7 +3,7 @@ title: "Rebecca Wigmore"
 firstname: "rebecca"
 pronouns: "She/her"
 job: "Writer"
-jobtype: staff
+jobtype: alum
 dataname: rebecca
 avatar: rebecca.jpg
 ---


### PR DESCRIPTION
Fixes #391

## Description

- Set job types to Alum so they do not show up on the team page but retain data so they don't break blogposts, project credits, etc.

@geeksforsocialchange/developers
