### PR TITLE
remove developers from staff list as part of redundancy admin

### DIFF
--- a/content/team/staff/alfie/index.md
+++ b/content/team/staff/alfie/index.md
@@ -3,7 +3,7 @@ title: "Alfie"
 firstname: "Alfie"
 pronouns: "He/him"
 job: "Developer"
-jobtype: staff
+jobtype: alum
 dataname: alfie
 avatar: alfie@400.jpg
 ---

--- a/content/team/staff/ivan/index.md
+++ b/content/team/staff/ivan/index.md
@@ -3,7 +3,7 @@ title: "Ivan Kocienski"
 firstname: "Ivan"
 pronouns: "He/him"
 job: "Developer"
-jobtype: staff
+jobtype: alum
 dataname: ivan
 avatar: ivan@400.jpg
 ---

--- a/content/team/staff/rosie/index.md
+++ b/content/team/staff/rosie/index.md
@@ -3,7 +3,7 @@ title: "Rosie Ferrier"
 firstname: "Rosie"
 pronouns: "She/her"
 job: "Developer"
-jobtype: staff
+jobtype: alum
 dataname: rosie
 avatar: rosie@400.jpg
 ---


### PR DESCRIPTION
Pretty self explanatory, just cleaning up loose ends.

@geeksforsocialchange/developers
